### PR TITLE
build(ci): buf lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,6 @@ jobs:
       - run: make lint
       - run: make proto-breaking
       - run: make sec
-      - run: make specs
       - run: make features
       - run: make build analyse
       - save_cache:

--- a/api/buf.yaml
+++ b/api/buf.yaml
@@ -5,4 +5,4 @@ breaking:
     - FILE
 lint:
   use:
-    - DEFAULT
+    - STANDARD


### PR DESCRIPTION
WARN	Category DEFAULT referenced in your buf.yaml is deprecated. It has been replaced by category STANDARD.
