### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.391.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/alexfalkowski/go-health/v2 v2.19.2
-	github.com/alexfalkowski/go-service/v2 v2.389.0
+	github.com/alexfalkowski/go-service/v2 v2.391.1
 	github.com/google/uuid v1.6.0
 	github.com/linxGnu/mssqlx v1.1.8
 	github.com/matoous/go-nanoid v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.19.2 h1:wsqGEevu5mF0+/3QNABgB7R2gpGk4j9fwuMtbzIVzuo=
 github.com/alexfalkowski/go-health/v2 v2.19.2/go.mod h1:ypy+lqZpEh2HPNLqaDAv6wJBbxuouOZoPkkrtrMNXrA=
-github.com/alexfalkowski/go-service/v2 v2.389.0 h1:r2hVEJLmV20hXOuKdgeuzdUeFWt7WW4hWdV4Wuofdhs=
-github.com/alexfalkowski/go-service/v2 v2.389.0/go.mod h1:LmLPj1YcbJM8iJ9AF1nyqt236D108Kh1YqitTlZYhAA=
+github.com/alexfalkowski/go-service/v2 v2.391.1 h1:wJLe4PUa7wWu7eR1VaNdUD3aP0AQ87sGi/ZnnY2uhoQ=
+github.com/alexfalkowski/go-service/v2 v2.391.1/go.mod h1:LmLPj1YcbJM8iJ9AF1nyqt236D108Kh1YqitTlZYhAA=
 github.com/alexfalkowski/go-sync v1.21.0 h1:Aydt3mB0FwmaRPjDsO4ZHJIa0HdueTwRt0i4NQtNvsA=
 github.com/alexfalkowski/go-sync v1.21.0/go.mod h1:J2yBCIWJ1YAWqAJ94Bt2xroR2rOWlSyRBGqqNJDmLBw=
 github.com/arl/statsviz v0.8.0 h1:O6GjjVxEDxcByAucOSl29HaGYLXsuwA3ujJw8H9E7/U=


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.391.1
