### PR TITLE
fix(generator): return unavailable errors for missing dependencies

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -10,6 +10,10 @@ import (
 // ErrNotFound indicates that a generator kind cannot be resolved from a registry.
 var ErrNotFound = errors.New("generator not found")
 
+// ErrUnavailable indicates that a generator cannot produce identifiers because
+// a required runtime dependency is unavailable.
+var ErrUnavailable = errors.New("generator unavailable")
+
 // NewGenerators constructs the default generator registry.
 //
 // The returned registry maps a generator "kind" string (for example "uuid" or

--- a/internal/generator/pg.go
+++ b/internal/generator/pg.go
@@ -15,6 +15,10 @@ type PG struct {
 
 // Generate an ID using a sequence.
 func (p *PG) Generate(ctx context.Context, app *Application) (string, error) {
+	if p.db == nil {
+		return strings.Empty, ErrUnavailable
+	}
+
 	var id int64
 
 	row := p.db.QueryRowContext(ctx, "SELECT nextval($1::regclass)", app.Name)

--- a/internal/generator/snowflake.go
+++ b/internal/generator/snowflake.go
@@ -20,6 +20,10 @@ func NewSnowflake() *Snowflake {
 
 // Generate a id with snowflake.
 func (s *Snowflake) Generate(_ context.Context, app *Application) (string, error) {
+	if s.sf == nil {
+		return strings.Empty, ErrUnavailable
+	}
+
 	id, err := s.sf.NextID()
 	if err != nil {
 		return strings.Empty, err


### PR DESCRIPTION
## What
- Add `ErrUnavailable` for unavailable identifier generation dependencies.
- Return an empty ID with `ErrUnavailable` when the Postgres DB handle is nil.
- Return an empty ID with `ErrUnavailable` when the Sonyflake instance is nil.

## Why
- Prevent request-time nil-pointer panics when runtime dependencies are unavailable.
- Preserve normal error propagation so transports can return controlled internal errors.

## Testing
- `go test ./internal/generator`
- `make lint`
- `make features` (55 scenarios, 118 steps)

AI-assisted-by: [Codex](https://openai.com/codex/)
