### PR TITLE
feat(security): validate service configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ vendor
 /bezeichner
 dist
 .source-key
+ISSUES.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,12 @@ Generator implementations are in `internal/generator/*` and are selected by `App
 - The pg generator uses a Postgres sequence named after `Application.Name` and calls `nextval($1::regclass)` (see `internal/generator/pg.go:16-26`).
 - The service does **not** create sequences; you must provision them externally.
 
+### Snowflake generator deployment assumption
+
+- Do **not** flag `internal/generator/snowflake.go` using Sonyflake default settings as a general bug.
+- In the intended Kubernetes deployment, pods use normal pod networking, so Sonyflake's default private-IPv4-derived machine ID is an accepted uniqueness source for concurrently running pods.
+- Only raise Snowflake machine-ID collision risk when the task explicitly concerns local multi-process deployments, `hostNetwork`, overlapping pod CIDRs, multi-cluster shared ID spaces, IPv6-only/no-private-IPv4 environments, or changing the deployment topology/ID contract.
+
 ## Request size limits (DoS protection)
 
 Limits are enforced in the domain layer:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,10 +9,10 @@ import (
 
 // Config for the service.
 type Config struct {
-	Health         *health.Config    `yaml:"health,omitempty" json:"health,omitempty" toml:"health,omitempty"`
-	Generator      *generator.Config `yaml:"generator,omitempty" json:"generator,omitempty" toml:"generator,omitempty"`
-	Mapper         *mapper.Config    `yaml:"mapper,omitempty" json:"mapper,omitempty" toml:"mapper,omitempty"`
-	*config.Config `yaml:",inline" json:",inline" toml:",inline"`
+	Health         *health.Config    `yaml:"health,omitempty" json:"health,omitempty" toml:"health,omitempty" validate:"required"`
+	Generator      *generator.Config `yaml:"generator,omitempty" json:"generator,omitempty" toml:"generator,omitempty" validate:"required"`
+	Mapper         *mapper.Config    `yaml:"mapper,omitempty" json:"mapper,omitempty" toml:"mapper,omitempty" validate:"required"`
+	*config.Config `yaml:",inline" json:",inline" toml:",inline" validate:"required"`
 }
 
 func decorateConfig(cfg *Config) *config.Config {

--- a/internal/generator/pg.go
+++ b/internal/generator/pg.go
@@ -21,7 +21,8 @@ func (p *PG) Generate(ctx context.Context, app *Application) (string, error) {
 
 	var id int64
 
-	row := p.db.QueryRowContext(ctx, "SELECT nextval($1::regclass)", app.Name)
+	// nextval advances sequence state, so it must run against the master pool.
+	row := p.db.QueryRowContextOnMaster(ctx, "SELECT nextval($1::regclass)", app.Name)
 	if err := row.Scan(&id); err != nil {
 		return strings.Empty, err
 	}

--- a/internal/health/config.go
+++ b/internal/health/config.go
@@ -12,6 +12,6 @@ import "github.com/alexfalkowski/go-service/v2/time"
 //   - Duration: the interval between health check executions.
 //   - Timeout: the maximum amount of time a health check is allowed to run.
 type Config struct {
-	Duration time.Duration `yaml:"duration,omitempty" json:"duration,omitempty" toml:"duration,omitempty"`
-	Timeout  time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" toml:"timeout,omitempty"`
+	Duration time.Duration `yaml:"duration,omitempty" json:"duration,omitempty" toml:"duration,omitempty" validate:"gt=0"`
+	Timeout  time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" toml:"timeout,omitempty" validate:"gt=0"`
 }


### PR DESCRIPTION
## What

- Route Postgres sequence generation through the master pool and document why `nextval` cannot use read replicas.
- Require core service config sections and positive health durations at startup validation time.
- Document the accepted Kubernetes Snowflake machine-ID assumption and ignore scoped issue ledgers.

## Why

- Prevent runtime panics or invalid health probes from omitted config while keeping failures in startup validation.
- Avoid sending sequence-mutating queries to read replicas.
- Capture the Snowflake deployment decision so future reviews do not re-raise the dismissed local-topology concern.

## Testing

- `go test ./internal/...` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
