### PR TITLE
fix(config): handle optional mappings

### DIFF
--- a/internal/api/ids/ids.go
+++ b/internal/api/ids/ids.go
@@ -92,6 +92,10 @@ func (s *Identifier) Map(ids []string) ([]string, error) {
 		return nil, ErrInvalidArgument
 	}
 
+	if s.mapperConfig == nil {
+		return nil, ErrNotFound
+	}
+
 	mids := make([]string, len(ids))
 	for i, id := range ids {
 		mid, ok := s.mapperConfig.Identifiers[id]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,7 +11,7 @@ import (
 type Config struct {
 	Health         *health.Config    `yaml:"health,omitempty" json:"health,omitempty" toml:"health,omitempty" validate:"required"`
 	Generator      *generator.Config `yaml:"generator,omitempty" json:"generator,omitempty" toml:"generator,omitempty" validate:"required"`
-	Mapper         *mapper.Config    `yaml:"mapper,omitempty" json:"mapper,omitempty" toml:"mapper,omitempty" validate:"required"`
+	Mapper         *mapper.Config    `yaml:"mapper,omitempty" json:"mapper,omitempty" toml:"mapper,omitempty"`
 	*config.Config `yaml:",inline" json:",inline" toml:",inline" validate:"required"`
 }
 


### PR DESCRIPTION
## What

- Allow the mapper configuration section to be omitted from startup validation.
- Return `ErrNotFound` from `MapIdentifiers` when mapping is requested without mapper configuration, while preserving request-size validation first.

## Why

- Mapper configuration is optional, but omitted mapper state should fail cleanly instead of panicking at request time.
- Keeping the size guard first preserves the existing request limit behavior.

## Testing

- `go test ./internal/...` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
