### PR TITLE
test(feature): cover identifier boundary contracts

### DIFF
--- a/test/.config/server.yml
+++ b/test/.config/server.yml
@@ -9,6 +9,8 @@ generator:
   applications:
     - name: uuid
       kind: uuid
+    - name: uuid_alias
+      kind: uuid
     - name: ksuid
       kind: ksuid
     - name: ulid
@@ -22,6 +24,8 @@ generator:
     - name: typeid
       kind: typeid
     - name: pg
+      kind: pg
+    - name: pg_alias
       kind: pg
     - name: invalid_kind
       kind: invalid_kind

--- a/test/features/step_definitions/v1/transport/grpc/api_steps.rb
+++ b/test/features/step_definitions/v1/transport/grpc/api_steps.rb
@@ -32,19 +32,37 @@ rescue StandardError => e
   @response = e
 end
 
+When('I request to map {int} existing identifiers with gRPC') do |count|
+  @request_id = SecureRandom.uuid
+  metadata = { 'request-id' => @request_id }
+
+  request = Bezeichner::V1::MapIdentifiersRequest.new(ids: Array.new(count, 'req1'))
+  @response = Bezeichner::V1.grpc.map_identifiers(request, { metadata: })
+rescue StandardError => e
+  @response = e
+end
+
 Then('I should receive generated identifiers from gRPC:') do |table|
   rows = table.rows_hash
 
-  expect(@response.meta.length).to be > 0
+  expect(@response.meta['requestId']).to eq(@request_id)
+  expect(@response.meta['userAgent']).to include('Bezeichner-ruby-client/1.0 gRPC/1.0')
   expect(@response.ids.length).to eq(rows['count'].to_i)
-  expect(@response.ids.first.length).to be > 0
+  expect(@response.ids).to all(satisfy { |id| id.length.positive? })
 end
 
 Then('I should receive mapped identifiers from gRPC:') do |table|
   rows = table.rows_hash
 
-  expect(@response.meta.length).to be > 0
+  expect(@response.meta['requestId']).to eq(@request_id)
+  expect(@response.meta['userAgent']).to include('Bezeichner-ruby-client/1.0 gRPC/1.0')
   expect(@response.ids).to eq(rows['response'].split(','))
+end
+
+Then('I should receive {int} mapped identifiers from gRPC') do |count|
+  expect(@response.meta['requestId']).to eq(@request_id)
+  expect(@response.meta['userAgent']).to include('Bezeichner-ruby-client/1.0 gRPC/1.0')
+  expect(@response.ids).to eq(Array.new(count, 'resp1'))
 end
 
 Then('I should receive a not found error from gRPC') do

--- a/test/features/step_definitions/v1/transport/http/api_steps.rb
+++ b/test/features/step_definitions/v1/transport/http/api_steps.rb
@@ -2,9 +2,10 @@
 
 When('I request to generate identifiers with HTTP:') do |table|
   rows = table.rows_hash
+  @request_id = SecureRandom.uuid
   opts = {
     headers: {
-      request_id: SecureRandom.uuid, user_agent: 'Bezeichner-ruby-client/1.0 HTTP/1.0',
+      request_id: @request_id, user_agent: 'Bezeichner-ruby-client/1.0 HTTP/1.0',
       content_type: :json, accept: :json
     },
     read_timeout: 10, open_timeout: 10
@@ -15,9 +16,10 @@ end
 
 When('I request to map identifiers with HTTP:') do |table|
   rows = table.rows_hash
+  @request_id = SecureRandom.uuid
   opts = {
     headers: {
-      request_id: SecureRandom.uuid, user_agent: 'Bezeichner-ruby-client/1.0 HTTP/1.0',
+      request_id: @request_id, user_agent: 'Bezeichner-ruby-client/1.0 HTTP/1.0',
       content_type: :json, accept: :json
     },
     read_timeout: 10, open_timeout: 10
@@ -27,15 +29,29 @@ When('I request to map identifiers with HTTP:') do |table|
 end
 
 When('I request to map {int} identifiers with HTTP:') do |count|
+  @request_id = SecureRandom.uuid
   opts = {
     headers: {
-      request_id: SecureRandom.uuid, user_agent: 'Bezeichner-ruby-client/1.0 HTTP/1.0',
+      request_id: @request_id, user_agent: 'Bezeichner-ruby-client/1.0 HTTP/1.0',
       content_type: :json, accept: :json
     },
     read_timeout: 10, open_timeout: 10
   }
 
   @response = Bezeichner::V1.http.map(count.times.map { SecureRandom.hex }, opts)
+end
+
+When('I request to map {int} existing identifiers with HTTP') do |count|
+  @request_id = SecureRandom.uuid
+  opts = {
+    headers: {
+      request_id: @request_id, user_agent: 'Bezeichner-ruby-client/1.0 HTTP/1.0',
+      content_type: :json, accept: :json
+    },
+    read_timeout: 10, open_timeout: 10
+  }
+
+  @response = Bezeichner::V1.http.map(Array.new(count, 'req1'), opts)
 end
 
 Then('I should receive generated identifiers from HTTP:') do |table|
@@ -45,9 +61,10 @@ Then('I should receive generated identifiers from HTTP:') do |table|
   ids = resp['ids']
   rows = table.rows_hash
 
-  expect(resp['meta'].length).to be > 0
+  expect(resp['meta']['requestId']).to eq(@request_id)
+  expect(resp['meta']['userAgent']).to eq('Bezeichner-ruby-client/1.0 HTTP/1.0')
   expect(ids.length).to eq(rows['count'].to_i)
-  expect(ids.first.length).to be > 0
+  expect(ids).to all(satisfy { |id| id.length.positive? })
 end
 
 Then('I should receive mapped identifiers from HTTP:') do |table|
@@ -57,8 +74,19 @@ Then('I should receive mapped identifiers from HTTP:') do |table|
   ids = resp['ids']
   rows = table.rows_hash
 
-  expect(resp['meta'].length).to be > 0
+  expect(resp['meta']['requestId']).to eq(@request_id)
+  expect(resp['meta']['userAgent']).to eq('Bezeichner-ruby-client/1.0 HTTP/1.0')
   expect(ids).to eq(rows['response'].split(','))
+end
+
+Then('I should receive {int} mapped identifiers from HTTP') do |count|
+  expect(@response.code).to eq(200)
+
+  resp = JSON.parse(@response.body)
+
+  expect(resp['meta']['requestId']).to eq(@request_id)
+  expect(resp['meta']['userAgent']).to eq('Bezeichner-ruby-client/1.0 HTTP/1.0')
+  expect(resp['ids']).to eq(Array.new(count, 'resp1'))
 end
 
 Then('I should receive a not found error from HTTP') do

--- a/test/features/support/generator.rb
+++ b/test/features/support/generator.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
-Bezeichner.pg.create
+%w[pg pg_alias].each do |name|
+  Bezeichner.pg.create(name)
+end
 
 at_exit do
-  Bezeichner.pg.destroy
+  %w[pg_alias pg].each do |name|
+    Bezeichner.pg.destroy(name)
+  end
 end

--- a/test/features/v1/transport/grpc/api.feature
+++ b/test/features/v1/transport/grpc/api.feature
@@ -13,6 +13,7 @@ Feature: gRPC API
       | application | count |
       | uuid        |     1 |
       | uuid        |     2 |
+      | uuid_alias  |     1 |
       | ksuid       |     1 |
       | ksuid       |     2 |
       | ulid        |     1 |
@@ -27,6 +28,15 @@ Feature: gRPC API
       | typeid      |     2 |
       | pg          |     1 |
       | pg          |     2 |
+      | pg_alias    |     1 |
+
+  Scenario: Generate maximum identifiers for existing applications
+    When I request to generate identifiers with gRPC:
+      | application | uuid |
+      | count       | 1000 |
+    Then I should receive generated identifiers from gRPC:
+      | application | uuid |
+      | count       | 1000 |
 
   Scenario: Generate too many identifiers for existing applications
     When I request to generate identifiers with gRPC:
@@ -69,6 +79,11 @@ Feature: gRPC API
       | request   | response    |
       | req1      | resp1       |
       | req1,req2 | resp1,resp2 |
+      | req2,req1 | resp2,resp1 |
+
+  Scenario: Map maximum identifiers
+    When I request to map 1000 existing identifiers with gRPC
+    Then I should receive 1000 mapped identifiers from gRPC
 
   Scenario: Map too many identifiers
     When I request to map 1001 identifiers with gRPC:

--- a/test/features/v1/transport/http/api.feature
+++ b/test/features/v1/transport/http/api.feature
@@ -13,6 +13,7 @@ Feature: HTTP API
       | application | count |
       | uuid        |     1 |
       | uuid        |     2 |
+      | uuid_alias  |     1 |
       | ksuid       |     1 |
       | ksuid       |     2 |
       | ulid        |     1 |
@@ -27,6 +28,15 @@ Feature: HTTP API
       | typeid      |     2 |
       | pg          |     1 |
       | pg          |     2 |
+      | pg_alias    |     1 |
+
+  Scenario: Generate maximum identifiers for existing applications
+    When I request to generate identifiers with HTTP:
+      | application | uuid |
+      | count       | 1000 |
+    Then I should receive generated identifiers from HTTP:
+      | application | uuid |
+      | count       | 1000 |
 
   Scenario: Generate too many identifiers for existing applications
     When I request to generate identifiers with HTTP:
@@ -69,6 +79,11 @@ Feature: HTTP API
       | request   | response    |
       | req1      | resp1       |
       | req1,req2 | resp1,resp2 |
+      | req2,req1 | resp2,resp1 |
+
+  Scenario: Map maximum identifiers
+    When I request to map 1000 existing identifiers with HTTP
+    Then I should receive 1000 mapped identifiers from HTTP
 
   Scenario: Map too many identifiers
     When I request to map 1001 identifiers with HTTP:

--- a/test/lib/bezeichner/generator/pg.rb
+++ b/test/lib/bezeichner/generator/pg.rb
@@ -42,20 +42,28 @@ module Bezeichner
         @conn = ::PG.connect(uri.hostname, uri.port, nil, nil, uri.path[1..], uri.user, uri.password)
       end
 
-      # Creates the `pg` sequence.
+      # Creates the named sequence.
       #
+      # @param name [String] sequence name
       # @return [PG::Result] result from Postgres
       # @raise [PG::Error] if the sequence already exists or the command fails
-      def create
-        @conn.exec('CREATE SEQUENCE pg')
+      def create(name = 'pg')
+        @conn.exec("CREATE SEQUENCE #{sequence(name)}")
       end
 
-      # Drops the `pg` sequence.
+      # Drops the named sequence.
       #
+      # @param name [String] sequence name
       # @return [PG::Result] result from Postgres
       # @raise [PG::Error] if the sequence does not exist or the command fails
-      def destroy
-        @conn.exec('DROP SEQUENCE pg')
+      def destroy(name = 'pg')
+        @conn.exec("DROP SEQUENCE #{sequence(name)}")
+      end
+
+      private
+
+      def sequence(name)
+        @conn.quote_ident(name)
       end
     end
   end


### PR DESCRIPTION
## What

- Add API feature coverage for generator aliases, maximum request sizes, mapper ordering, and metadata propagation.
- Generalize the Postgres sequence fixture so pg-backed alias applications are provisioned.
- Tighten generated identifier assertions to verify every returned ID is populated.

## Why

- Protect repository-owned identifier behavior that was previously only covered by small happy-path examples.

## Testing

- `make features` - passed
- `make lint` - passed
