### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.555.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/alexfalkowski/go-health/v2 v2.24.0
-	github.com/alexfalkowski/go-service/v2 v2.554.0
+	github.com/alexfalkowski/go-service/v2 v2.555.0
 	github.com/google/uuid v1.6.0
 	github.com/matoous/go-nanoid v1.5.1
 	github.com/oklog/ulid v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.24.0 h1:4XDD5OorJoW1vG26RM+FVA5Au8I9PpwXD6g07kCtcmA=
 github.com/alexfalkowski/go-health/v2 v2.24.0/go.mod h1:ypy+lqZpEh2HPNLqaDAv6wJBbxuouOZoPkkrtrMNXrA=
-github.com/alexfalkowski/go-service/v2 v2.554.0 h1:cfmu0FpaNW1FqSagvSGJQIIkd12Dxv1af8GQF+rXb9U=
-github.com/alexfalkowski/go-service/v2 v2.554.0/go.mod h1:QbSw4BmraRMSfAOX6Jsmefqx30lS0PAELwUJFWYLp74=
+github.com/alexfalkowski/go-service/v2 v2.555.0 h1:bwfFoOmId21kz7dYvWdCSd/F3+/HixHpzQP+XDe5Vgk=
+github.com/alexfalkowski/go-service/v2 v2.555.0/go.mod h1:QbSw4BmraRMSfAOX6Jsmefqx30lS0PAELwUJFWYLp74=
 github.com/alexfalkowski/go-sync v1.21.0 h1:Aydt3mB0FwmaRPjDsO4ZHJIa0HdueTwRt0i4NQtNvsA=
 github.com/alexfalkowski/go-sync v1.21.0/go.mod h1:J2yBCIWJ1YAWqAJ94Bt2xroR2rOWlSyRBGqqNJDmLBw=
 github.com/arl/statsviz v0.8.0 h1:O6GjjVxEDxcByAucOSl29HaGYLXsuwA3ujJw8H9E7/U=


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.555.0
