### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.565.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/alexfalkowski/go-health/v2 v2.26.0
-	github.com/alexfalkowski/go-service/v2 v2.564.0
+	github.com/alexfalkowski/go-service/v2 v2.565.0
 	github.com/sony/sonyflake v1.3.0
 	go.jetify.com/typeid v1.3.0
 	google.golang.org/grpc v1.81.1

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.26.0 h1:gBC3QxBxgY8c+6YxEbvRitNu7TycVE/mWRg+smvDkGs=
 github.com/alexfalkowski/go-health/v2 v2.26.0/go.mod h1:k2YV+Yzkf/iOXWBSAqQbzocXFtU5D3C68+Xt00JyVhk=
-github.com/alexfalkowski/go-service/v2 v2.564.0 h1:+nIoQ+X6RQN+nfiHFiec2FxlWRJk2R1f20DXaHLvRQQ=
-github.com/alexfalkowski/go-service/v2 v2.564.0/go.mod h1:i+DUuyTJGkNsfs/MwSqHk+szEG3uz3U3sm7l9pplhM8=
+github.com/alexfalkowski/go-service/v2 v2.565.0 h1:+BdTc30uo4fKqw6UMpv+Bwm4hInZdff/gCoAn6KKISs=
+github.com/alexfalkowski/go-service/v2 v2.565.0/go.mod h1:i+DUuyTJGkNsfs/MwSqHk+szEG3uz3U3sm7l9pplhM8=
 github.com/alexfalkowski/go-sync v1.23.0 h1:ir7b0LQFxJBYPhd2bb95iVq3T5SN+qBRWF2XKu3fCrM=
 github.com/alexfalkowski/go-sync v1.23.0/go.mod h1:2vmRtpHHSoGPIiXJ7j3lm0GK2SI32XbYvvrjrZ+eo/k=
 github.com/arl/statsviz v0.8.0 h1:O6GjjVxEDxcByAucOSl29HaGYLXsuwA3ujJw8H9E7/U=


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.565.0
