### PR TITLE
test(reliability): document release assumptions and bound grpc calls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,12 @@ Notes:
 - The generator application model in code currently includes only `name` and `kind` (no `prefix`, `suffix`, or `separator` fields).
 - HTTP is an RPC gateway that routes by **gRPC full method name**, so the HTTP surface mirrors the gRPC contract in `api/bezeichner/v1/service.proto`.
 
+### Health check deployment assumption
+
+- Do **not** flag `internal/health` wiring `healthz` to the `online` check as a reliability gap.
+- This is an intentional shared service convention: all services should know whether they can talk to the outside world if public egress is needed later, even when Bezeichner's current generate/map paths do not require outbound network access.
+- Only raise this health check behavior when the task explicitly concerns changing the health contract, environments that must run without public egress, or a documented operator workflow where `healthz` must mean local-process-only health.
+
 ## Generators
 
 Generator implementations are in `internal/generator/*` and are selected by `Application.Kind`.
@@ -165,6 +171,18 @@ from `github.com/alexfalkowski/go-service/v2/id`.
 - Do **not** flag `internal/generator/snowflake.go` using Sonyflake default settings as a general bug.
 - In the intended Kubernetes deployment, pods use normal pod networking, so Sonyflake's default private-IPv4-derived machine ID is an accepted uniqueness source for concurrently running pods.
 - Only raise Snowflake machine-ID collision risk when the task explicitly concerns local multi-process deployments, `hostNetwork`, overlapping pod CIDRs, multi-cluster shared ID spaces, IPv6-only/no-private-IPv4 environments, or changing the deployment topology/ID contract.
+
+### Docker release ordering assumption
+
+- Do **not** flag `.circleci/config.yml` for not serializing the post-`version` Docker push, manifest, or deploy jobs merely because the moving `latest` manifest could be updated out of order.
+- This is an accepted release tradeoff: deployments and consumers are expected to pin released version tags, and the versioned image tag is the deployment contract.
+- Only raise release ordering risk when the task explicitly concerns `latest` consumers, unpinned image deployment, versioned tag overwrite, partial versioned artifact publication, or changing the release/deploy contract.
+
+### Docker image scan assumption
+
+- Do **not** flag `.circleci/config.yml` for not running the Docker build/Trivy image jobs on `master` before `push-docker` merely because release image publication builds the versioned image during push.
+- The intended validation model scans the test Docker image (`alexfalkowski/<name>:test.<platform>`) built by `make build-docker`; `make trivy-image` scans that tag, and the release image uses the same Dockerfile and runtime contents with the release version passed as metadata.
+- Only raise Docker image pre-publish gating risk when the Dockerfile, build script, or release process changes so the scanned test image and published versioned image can materially differ, or when the task explicitly concerns release image scanning policy.
 
 ## Request size limits (DoS protection)
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ The service registers:
 
 - `noop` and `online` checks.
 
+`healthz` intentionally uses the `online` check. Bezeichner follows the shared
+service convention that all services should report whether they can reach the
+outside world if they need public egress later, even when the current generate
+and map paths do not require outbound network access.
+
 The service exposes health observers for HTTP (`healthz`, `livez`, `readyz`) and gRPC health checks.
 
 ## 🚀 Running
@@ -197,6 +202,12 @@ Bezeichner is typically deployed as a shared internal service. Depending on your
 
 > [!CAUTION]
 > The `snowflake` generator uses Sonyflake defaults. The intended deployment assumes normal Kubernetes pod networking where each concurrently running pod has a suitable private IPv4-derived machine ID. Re-evaluate that assumption for local multi-process deployments, `hostNetwork`, overlapping pod CIDRs, multi-cluster shared ID spaces, IPv6-only environments, or environments without private IPv4 addresses.
+
+> [!IMPORTANT]
+> Deployments should pin released version tags instead of depending on the moving
+> `latest` Docker manifest. The release pipeline may update `latest` after
+> versioned images are published, but the versioned image tag is the deployment
+> contract.
 
 ## 🔗 Design & dependencies
 

--- a/test/features/step_definitions/health/transport/grpc/observability_steps.rb
+++ b/test/features/step_definitions/health/transport/grpc/observability_steps.rb
@@ -2,7 +2,7 @@
 
 When('the system requests the health status with gRPC') do
   request = Grpc::Health::V1::HealthCheckRequest.new(service: 'bezeichner.v1.Service')
-  @response = Bezeichner.health_grpc.check(request)
+  @response = Bezeichner.health_grpc.check(request, Bezeichner.grpc_options)
 end
 
 Then('the system should respond with a healthy status with gRPC') do

--- a/test/features/step_definitions/v1/transport/grpc/api_steps.rb
+++ b/test/features/step_definitions/v1/transport/grpc/api_steps.rb
@@ -6,7 +6,7 @@ When('I request to generate identifiers with gRPC:') do |table|
   metadata = { 'request-id' => @request_id }
 
   request = Bezeichner::V1::GenerateIdentifiersRequest.new(application: rows['application'], count: rows['count'].to_i)
-  @response = Bezeichner::V1.grpc.generate_identifiers(request, { metadata: })
+  @response = Bezeichner::V1.grpc.generate_identifiers(request, Bezeichner.grpc_options(metadata:))
 rescue StandardError => e
   @response = e
 end
@@ -17,7 +17,7 @@ When('I request to map identifiers with gRPC:') do |table|
   metadata = { 'request-id' => @request_id }
 
   request = Bezeichner::V1::MapIdentifiersRequest.new(ids: rows['request'].split(','))
-  @response = Bezeichner::V1.grpc.map_identifiers(request, { metadata: })
+  @response = Bezeichner::V1.grpc.map_identifiers(request, Bezeichner.grpc_options(metadata:))
 rescue StandardError => e
   @response = e
 end
@@ -27,7 +27,7 @@ When('I request to map {int} identifiers with gRPC:') do |count|
   metadata = { 'request-id' => @request_id }
 
   request = Bezeichner::V1::MapIdentifiersRequest.new(ids: count.times.map { SecureRandom.hex })
-  @response = Bezeichner::V1.grpc.map_identifiers(request, { metadata: })
+  @response = Bezeichner::V1.grpc.map_identifiers(request, Bezeichner.grpc_options(metadata:))
 rescue StandardError => e
   @response = e
 end
@@ -37,7 +37,7 @@ When('I request to map {int} existing identifiers with gRPC') do |count|
   metadata = { 'request-id' => @request_id }
 
   request = Bezeichner::V1::MapIdentifiersRequest.new(ids: Array.new(count, 'req1'))
-  @response = Bezeichner::V1.grpc.map_identifiers(request, { metadata: })
+  @response = Bezeichner::V1.grpc.map_identifiers(request, Bezeichner.grpc_options(metadata:))
 rescue StandardError => e
   @response = e
 end

--- a/test/features/step_definitions/v1/transport/grpc/benchmark_steps.rb
+++ b/test/features/step_definitions/v1/transport/grpc/benchmark_steps.rb
@@ -4,5 +4,5 @@ When('I request to generate identifiers with gRPC which performs in {int} ms') d
   metadata = { 'request-id' => SecureRandom.uuid }
   request = Bezeichner::V1::GenerateIdentifiersRequest.new(application: 'ulid', count: 2)
 
-  expect { Bezeichner::V1.grpc.generate_identifiers(request, { metadata: }) }.to perform_under(time).ms
+  expect { Bezeichner::V1.grpc.generate_identifiers(request, Bezeichner.grpc_options(metadata:)) }.to perform_under(time).ms
 end

--- a/test/lib/bezeichner.rb
+++ b/test/lib/bezeichner.rb
@@ -56,6 +56,20 @@ module Bezeichner
       @health_grpc ||= Grpc::Health::V1::Health::Stub.new('localhost:12000', :this_channel_is_insecure, channel_args: Bezeichner.user_agent)
     end
 
+    # Builds per-call options for gRPC feature and benchmark requests.
+    #
+    # @param metadata [Hash] gRPC metadata to send with the request
+    # @return [Hash] gRPC call options
+    #
+    # @example Use metadata with a deadline
+    #   Bezeichner::V1.grpc.generate_identifiers(req, Bezeichner.grpc_options(metadata: { 'request-id' => request_id }))
+    def grpc_options(metadata: {})
+      {
+        metadata:,
+        deadline: Time.now + 10
+      }
+    end
+
     # Builds and memoizes the gRPC channel arguments used by stubs created in this helper.
     #
     # @return [Hash] gRPC channel args


### PR DESCRIPTION
## What

- Documents Bezeichner's accepted health check and Docker release assumptions so future reliability reviews do not re-raise intentionally accepted service conventions.
- Adds per-call gRPC deadlines to the Ruby feature and benchmark harness for API, health, and benchmark requests.
- Keeps the RPC deadline helper scoped to the test client helpers and preserves existing request metadata handling.

## Why

- The health and release notes make the intended operating contract explicit for reviewers and operators.
- The gRPC feature harness should fail boundedly if a service call stalls instead of waiting indefinitely.
- The change addresses the remaining REL-5 follow-up without altering production service behavior.

## Testing

- `make features feature=features/v1/transport/grpc/api.feature` - passed
- `make features feature=features/health/transport/grpc/observability.feature` - passed
- `make benchmarks feature=features/v1/transport/grpc/benchmark.feature` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
