### PR TITLE
feat(reliability): validate generator application lists

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,6 +206,30 @@ If bundler fails loading native gems (e.g., `json` extension), one observed fix 
 cd test && bundle pristine json
 ```
 
+### Feature harness readiness assumption
+
+- Do **not** flag `test/nonnative.yml` waiting on the gRPC port only as a
+  reliability gap merely because HTTP scenarios also use the HTTP listener.
+- This is intentional for the current nonnative workflow: HTTP listener failures
+  are surfaced by the HTTP feature scenarios themselves, and the single process
+  readiness gate keeps harness startup simple.
+- Only raise this if the task explicitly concerns changing feature-harness
+  startup semantics, making HTTP readiness a separate pre-scenario gate, or
+  investigating a concrete flaky/unclear HTTP feature failure.
+
+### Report artifact cleanup assumption
+
+- Do **not** flag `test/reports` artifacts as a reliability gap merely because
+  `features`, `benchmarks`, `specs`, or `coverage` do not automatically run
+  `make clean-reports`.
+- CI runs in a fresh job workspace, so stale local report artifacts are not part
+  of the repository-owned CI publication path.
+- For local work, `make clean-reports` is the explicit cleanup control.
+- Only raise report lifecycle risk when the task explicitly concerns changing
+  report cleanup/publication, CI workspace reuse, or there is concrete evidence
+  that a documented workflow published stale reports after the expected cleanup
+  path.
+
 ## Style / formatting
 
 - Go files use tabs (per `.editorconfig:16-18`).

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Generator configuration selects **applications**, each of which has:
 - a `name` (the public application key you pass on requests),
 - a `kind` (the generator implementation to use).
 
+Application entries must have non-empty `name` and `kind` values, and
+application names must be unique. Malformed application lists fail config
+validation during startup.
+
 Supported built-in kinds (at time of writing):
 
 - `uuid`

--- a/internal/generator/config.go
+++ b/internal/generator/config.go
@@ -7,8 +7,8 @@ package generator
 // Kind selects the generator implementation from a Generators registry (see
 // NewGenerators). For example: "uuid" or "ulid".
 type Application struct {
-	Name string `yaml:"name,omitempty" json:"name,omitempty" toml:"name,omitempty"`
-	Kind string `yaml:"kind,omitempty" json:"kind,omitempty" toml:"kind,omitempty"`
+	Name string `yaml:"name" json:"name" toml:"name" validate:"required"`
+	Kind string `yaml:"kind" json:"kind" toml:"kind" validate:"required"`
 }
 
 // Config contains the generator configuration.
@@ -16,7 +16,7 @@ type Application struct {
 // Applications is the set of generator applications available to the service.
 // Applications are addressed by Application.Name.
 type Config struct {
-	Applications []*Application `yaml:"applications,omitempty" json:"applications,omitempty" toml:"applications,omitempty"`
+	Applications []*Application `yaml:"applications" json:"applications" toml:"applications" validate:"unique=Name,dive,required"`
 }
 
 // Application returns the configured Application with the given name.

--- a/test/.config/duplicate_generator_names.yml
+++ b/test/.config/duplicate_generator_names.yml
@@ -1,0 +1,28 @@
+environment: production
+id:
+  kind: uuid
+mapper:
+  identifiers:
+    req1: resp1
+generator:
+  applications:
+    - name: duplicate
+      kind: uuid
+    - name: duplicate
+      kind: ulid
+health:
+  duration: 1s
+  timeout: 1s
+telemetry:
+  logger:
+    kind: text
+    level: info
+  metrics:
+    kind: prometheus
+transport:
+  http:
+    address: tcp://:11100
+    timeout: 5s
+  grpc:
+    address: tcp://:12100
+    timeout: 5s

--- a/test/.config/empty_generator_application.yml
+++ b/test/.config/empty_generator_application.yml
@@ -1,0 +1,26 @@
+environment: production
+id:
+  kind: uuid
+mapper:
+  identifiers:
+    req1: resp1
+generator:
+  applications:
+    - name:
+      kind: uuid
+health:
+  duration: 1s
+  timeout: 1s
+telemetry:
+  logger:
+    kind: text
+    level: info
+  metrics:
+    kind: prometheus
+transport:
+  http:
+    address: tcp://:11101
+    timeout: 5s
+  grpc:
+    address: tcp://:12101
+    timeout: 5s

--- a/test/.config/empty_generator_kind.yml
+++ b/test/.config/empty_generator_kind.yml
@@ -1,0 +1,26 @@
+environment: production
+id:
+  kind: uuid
+mapper:
+  identifiers:
+    req1: resp1
+generator:
+  applications:
+    - name: uuid
+      kind:
+health:
+  duration: 1s
+  timeout: 1s
+telemetry:
+  logger:
+    kind: text
+    level: info
+  metrics:
+    kind: prometheus
+transport:
+  http:
+    address: tcp://:11102
+    timeout: 5s
+  grpc:
+    address: tcp://:12102
+    timeout: 5s

--- a/test/.config/nil_generator_application.yml
+++ b/test/.config/nil_generator_application.yml
@@ -1,0 +1,25 @@
+environment: production
+id:
+  kind: uuid
+mapper:
+  identifiers:
+    req1: resp1
+generator:
+  applications:
+    -
+health:
+  duration: 1s
+  timeout: 1s
+telemetry:
+  logger:
+    kind: text
+    level: info
+  metrics:
+    kind: prometheus
+transport:
+  http:
+    address: tcp://:11103
+    timeout: 5s
+  grpc:
+    address: tcp://:12103
+    timeout: 5s

--- a/test/features/config/config.feature
+++ b/test/features/config/config.feature
@@ -1,0 +1,13 @@
+Feature: Configuration
+  Invalid configuration should stop the server from starting.
+
+  Scenario Outline: Reject invalid generator application lists
+    When I try to start the server with config "<config>"
+    Then the server should fail to start
+
+    Examples:
+      | config                            |
+      | duplicate_generator_names.yml     |
+      | empty_generator_application.yml   |
+      | empty_generator_kind.yml          |
+      | nil_generator_application.yml     |

--- a/test/features/step_definitions/config_steps.rb
+++ b/test/features/step_definitions/config_steps.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+When('I try to start the server with config {string}') do |config|
+  command = ['../bezeichner', 'server', '-config', "file:.config/#{config}"]
+  stdout = +''
+  stderr = +''
+
+  @server_status = nil
+  @server_timeout = false
+
+  Open3.popen3(*command) do |stdin, out, err, wait_thr|
+    stdin.close
+
+    begin
+      Timeout.timeout(3) do
+        @server_status = wait_thr.value
+      end
+    rescue Timeout::Error
+      @server_timeout = true
+      Process.kill('TERM', wait_thr.pid)
+      @server_status = wait_thr.value
+    end
+
+    stdout = out.read
+    stderr = err.read
+  end
+
+  @server_output = "#{stdout}\n#{stderr}"
+end
+
+Then('the server should fail to start') do
+  expect(@server_timeout).to be(false), @server_output
+  expect(@server_status).not_to be_success, @server_output
+end

--- a/test/lib/bezeichner.rb
+++ b/test/lib/bezeichner.rb
@@ -3,6 +3,8 @@
 require 'securerandom'
 require 'yaml'
 require 'base64'
+require 'open3'
+require 'timeout'
 
 require 'grpc/health/v1/health_services_pb'
 


### PR DESCRIPTION
## What

- Reject malformed generator application lists during startup config validation while preserving request-time handling for unknown generator kinds.
- Add feature-level startup scenarios and invalid config fixtures for duplicate generator names, empty names, empty kinds, and nil application entries.
- Document the generator config rejection rules and the accepted feature-harness/report-cleanup assumptions that should not be resurfaced as reliability gaps by default.

## Why

- Bad generator application entries should fail before the service accepts traffic instead of leaving ambiguous or malformed runtime configuration in place.
- The new feature coverage matches the repository's Cucumber-first validation pattern for service startup behavior.
- Documenting accepted assumptions keeps future reliability reviews focused on concrete current failure modes.

## Testing

- `make -C test lint` - passed
- `go test -mod=readonly ./internal/generator ./internal/config` - passed
- `make features feature=features/config/config.feature` - failed before Cucumber because `go.mod` requires `github.com/alexfalkowski/go-service/v2 v2.571.0` while `vendor/modules.txt` records `v2.570.0`
- `make specs` - failed before compiling for the same vendor mismatch
- `make lint` - failed before linting for the same vendor mismatch
