### PR TITLE
build(ci): serialize docker manifest releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,6 +250,7 @@ workflows:
               only: master
       - manifest-docker:
           context: docker
+          serial-group: << pipeline.project.slug >>/manifest-docker
           requires:
             - release-docker-amd64
             - release-docker-arm64

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,8 +174,10 @@ from `github.com/alexfalkowski/go-service/v2/id`.
 
 ### Docker release ordering assumption
 
-- Do **not** flag `.circleci/config.yml` for not serializing the post-`version` Docker push, manifest, or deploy jobs merely because the moving `latest` manifest could be updated out of order.
-- This is an accepted release tradeoff: deployments and consumers are expected to pin released version tags, and the versioned image tag is the deployment contract.
+- `.circleci/config.yml` serializes the `manifest-docker` workflow job with
+  `<< pipeline.project.slug >>/manifest-docker` so overlapping master pipelines
+  do not publish the moving `latest` manifest out of order.
+- Deployments and consumers are still expected to pin released version tags, and the versioned image tag is the deployment contract.
 - Only raise release ordering risk when the task explicitly concerns `latest` consumers, unpinned image deployment, versioned tag overwrite, partial versioned artifact publication, or changing the release/deploy contract.
 
 ## Request size limits (DoS protection)


### PR DESCRIPTION
## What

- Serialize the CircleCI `manifest-docker` workflow job with `<< pipeline.project.slug >>/manifest-docker`.
- Keep the existing Docker context, branch filter, architecture release dependencies, and deploy dependency unchanged.
- Update the repository agent notes to describe the new manifest serialization assumption.

## Why

- Prevent overlapping master pipelines from publishing the mutable `latest` Docker manifest out of order after the amd64 and arm64 images are pushed.
- Keep versioned image tags as the deployment contract while making the convenience manifest less race-prone.

## Testing

- `circleci config validate .circleci/config.yml` - passed
- `git diff --check` - passed
