### PR TITLE
docs(readme): clarify service contract and setup guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ matching skill for the task.
 
 ## Repository at a glance
 
-- Language: **Go** (`module github.com/alexfalkowski/bezeichner`, `go 1.25.0`; see `go.mod:1-3`).
+- Language: **Go** (`module github.com/alexfalkowski/bezeichner`; see `go.mod:1-3` for the current Go version).
 - API contract: `api/bezeichner/v1/service.proto` (+ generated Go stubs under `api/` and Ruby stubs under `test/lib`).
 - Build tooling: the root `Makefile` is a thin wrapper around the **`bin/` git submodule** (see `.gitmodules:1-3` and `Makefile:1-3`).
 
@@ -28,6 +28,10 @@ make submodule
 # see: bin/build/make/git.mak:29-31
 ```
 
+The `bin` submodule uses the SSH URL `git@github.com:alexfalkowski/bin.git`;
+this setup path requires GitHub SSH access unless you intentionally override the
+submodule URL in local Git configuration.
+
 ### 2) Install dependencies
 
 ```sh
@@ -35,7 +39,7 @@ make dep
 ```
 
 Observed behavior:
-- Go deps are vendored (`go mod vendor`) and most Go build/test targets use `-mod vendor` (see `bin/build/make/grpc.mak:214`).
+- Go deps are vendored (`go mod vendor`) and the test-binary build uses `-mod vendor` (see `bin/build/make/_service.mak:184-186`).
 - Ruby deps for feature tests live under `test/` and are installed via bundler into `test/vendor/bundle` (see `bin/build/make/ruby.mak:15-21` and `test/.bundle/config:1-2`).
 
 ## Essential commands
@@ -47,7 +51,7 @@ make build        # builds ./bezeichner (release binary)
 make build-test   # builds ./bezeichner test binary (-tags features, -race, coverage enabled)
 ```
 
-Implementation: `bin/build/make/grpc.mak:208-215`.
+Implementation: `bin/build/make/_service.mak:180-186`.
 
 ### Test
 
@@ -60,7 +64,7 @@ make coverage     # HTML + func coverage reports
 
 Notes:
 - `main_test.go` is guarded by build tag `features` (`main_test.go:1-10`).
-- `make features` depends on `make build-test` (see `bin/build/make/grpc.mak:126-128`).
+- `make features` depends on `make build-test` (see `bin/build/make/_service.mak:100-102`).
 
 ### Lint / format / security
 
@@ -80,6 +84,7 @@ make proto-lint
 make proto-format
 make proto-generate
 make proto-breaking
+make proto-stale
 ```
 
 Buf config is in `api/`:
@@ -95,10 +100,10 @@ make dev
 This uses `air` to rebuild/run the server:
 
 ```sh
-./bezeichner server -i file:test/.config/server.yml
+./bezeichner server -config file:test/.config/server.yml
 ```
 
-See `bin/build/make/grpc.mak:216-219`.
+See `bin/build/make/grpc.mak:51-53`.
 
 ### Environment helpers
 
@@ -107,7 +112,7 @@ make start
 make stop
 ```
 
-These call scripts under `bin/build/docker/env` (see `bin/build/make/grpc.mak:261-267`).
+These call scripts under `bin/build/docker/env` (see `bin/build/make/_service.mak:230-236`).
 
 ## Code organization
 
@@ -149,6 +154,7 @@ Notable keys observed:
 
 Notes:
 - The generator application model in code currently includes only `name` and `kind` (no `prefix`, `suffix`, or `separator` fields).
+- `mapper` is optional at startup; if it is omitted, all `MapIdentifiers` requests return `NotFound`.
 - HTTP is an RPC gateway that routes by **gRPC full method name**, so the HTTP surface mirrors the gRPC contract in `api/bezeichner/v1/service.proto`.
 
 ### Health check deployment assumption
@@ -193,13 +199,13 @@ These surface to clients as `InvalidArgument` via the gRPC error mapper (`intern
 
 ### Go specs
 
-`make specs` runs gotestsum with race and coverage (see `bin/build/make/grpc.mak:134-136`). Outputs land under `test/reports/`.
+`make specs` runs gotestsum with race and coverage (see `bin/build/make/_service.mak:108-111`). Outputs land under `test/reports/`.
 
 ### Feature tests (Ruby / nonnative)
 
 - Feature specs live under `test/features/**`.
 - Harness config: `test/nonnative.yml`.
-  - Launches `../bezeichner server -i file:.config/server.yml` (`test/nonnative.yml:6-12`).
+  - Launches `../bezeichner server -config file:.config/server.yml` (`test/nonnative.yml:6-12`).
 - Cucumber report options: `test/.config/cucumber.yml:1`.
 
 If bundler fails loading native gems (e.g., `json` extension), one observed fix is rebuilding the gem:
@@ -230,5 +236,5 @@ cd test && bundle pristine json
 
 CircleCI runs (see `.circleci/config.yml`):
 
-- `make dep`, `make lint`, `make proto-breaking`, `make sec`, `make trivy-repo`
+- `make dep`, `make lint`, `make proto-breaking`, `make proto-stale`, `make sec`
 - `make features`, `make benchmarks`, `make analyse`, `make coverage`, `make codecov-upload`

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Supported built-in kinds (at time of writing):
 - `xid`
 - `snowflake`
 - `nanoid`
-- `typeid`
+- `typeid` (prefixless TypeID string; prefix configuration is not currently exposed)
 
 Example:
 
@@ -95,6 +95,7 @@ mapper:
 
 > [!IMPORTANT]
 > Mapping is strict: if any input ID is missing from the table, the whole operation fails. Output order matches input order.
+> The `mapper` block is optional at startup. If it is omitted, all `MapIdentifiers` requests fail with `NotFound`.
 
 ### ❤️ Health configuration
 
@@ -129,6 +130,7 @@ make dev
 
 > [!IMPORTANT]
 > Run `make submodule` in a fresh checkout before other `make` targets. Most build, test, lint, and protobuf targets are provided by the `bin/` git submodule.
+> The submodule URL is SSH-based (`git@github.com:alexfalkowski/bin.git`), so this setup path requires GitHub SSH access.
 
 `make dev` runs the server using `air` and a config file like:
 
@@ -246,6 +248,10 @@ Most `make` targets come from the `bin/` git submodule:
 make submodule
 make dep
 ```
+
+The `bin` submodule is configured with a GitHub SSH URL, so `make submodule`
+requires GitHub SSH access unless you intentionally override the submodule URL
+in your local Git configuration.
 
 ### ✅ Tests
 

--- a/api/bezeichner/v1/service.pb.go
+++ b/api/bezeichner/v1/service.pb.go
@@ -21,11 +21,20 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// GenerateIdentifiersRequest for a specific application.
+// GenerateIdentifiersRequest asks the service to generate identifiers for a
+// configured application.
 type GenerateIdentifiersRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Application   string                 `protobuf:"bytes,1,opt,name=application,proto3" json:"application,omitempty"`
-	Count         uint64                 `protobuf:"varint,2,opt,name=count,proto3" json:"count,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// application is the configured generator application name.
+	//
+	// If the application is not configured, or if its configured kind cannot be
+	// resolved, GenerateIdentifiers fails with NotFound.
+	Application string `protobuf:"bytes,1,opt,name=application,proto3" json:"application,omitempty"`
+	// count is the number of identifiers to generate.
+	//
+	// The maximum accepted count is 1000. Larger requests fail with
+	// InvalidArgument.
+	Count         uint64 `protobuf:"varint,2,opt,name=count,proto3" json:"count,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -74,11 +83,15 @@ func (x *GenerateIdentifiersRequest) GetCount() uint64 {
 	return 0
 }
 
-// GenerateIdentifiersResponse for a specific application.
+// GenerateIdentifiersResponse contains generated identifiers and service
+// metadata.
 type GenerateIdentifiersResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Meta          map[string]string      `protobuf:"bytes,1,rep,name=meta,proto3" json:"meta,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	Ids           []string               `protobuf:"bytes,2,rep,name=ids,proto3" json:"ids,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// meta contains service and transport metadata. It is reserved for
+	// infrastructure metadata and is not business data.
+	Meta map[string]string `protobuf:"bytes,1,rep,name=meta,proto3" json:"meta,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// ids contains the generated identifiers.
+	Ids           []string `protobuf:"bytes,2,rep,name=ids,proto3" json:"ids,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -127,10 +140,17 @@ func (x *GenerateIdentifiersResponse) GetIds() []string {
 	return nil
 }
 
-// MapIdentifiersRequest for some identifiers.
+// MapIdentifiersRequest asks the service to map identifiers through the
+// configured mapper table.
 type MapIdentifiersRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Ids           []string               `protobuf:"bytes,1,rep,name=ids,proto3" json:"ids,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// ids contains the identifiers to map.
+	//
+	// The maximum accepted list length is 1000. Larger requests fail with
+	// InvalidArgument. Mapping is strict: if mapper configuration is omitted, or
+	// if any identifier is absent from the mapper table, MapIdentifiers fails
+	// with NotFound.
+	Ids           []string `protobuf:"bytes,1,rep,name=ids,proto3" json:"ids,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -172,11 +192,14 @@ func (x *MapIdentifiersRequest) GetIds() []string {
 	return nil
 }
 
-// MapIdentifiersResponse for some identifiers.
+// MapIdentifiersResponse contains mapped identifiers and service metadata.
 type MapIdentifiersResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Meta          map[string]string      `protobuf:"bytes,1,rep,name=meta,proto3" json:"meta,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	Ids           []string               `protobuf:"bytes,2,rep,name=ids,proto3" json:"ids,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// meta contains service and transport metadata. It is reserved for
+	// infrastructure metadata and is not business data.
+	Meta map[string]string `protobuf:"bytes,1,rep,name=meta,proto3" json:"meta,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// ids contains mapped identifiers in the same order as the request ids.
+	Ids           []string `protobuf:"bytes,2,rep,name=ids,proto3" json:"ids,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/api/bezeichner/v1/service.proto
+++ b/api/bezeichner/v1/service.proto
@@ -5,34 +5,67 @@ package bezeichner.v1;
 option go_package = "github.com/alexfalkowski/bezeichner/api/bezeichner/v1";
 option ruby_package = "Bezeichner::V1";
 
-// GenerateIdentifiersRequest for a specific application.
+// GenerateIdentifiersRequest asks the service to generate identifiers for a
+// configured application.
 message GenerateIdentifiersRequest {
+  // application is the configured generator application name.
+  //
+  // If the application is not configured, or if its configured kind cannot be
+  // resolved, GenerateIdentifiers fails with NotFound.
   string application = 1;
+
+  // count is the number of identifiers to generate.
+  //
+  // The maximum accepted count is 1000. Larger requests fail with
+  // InvalidArgument.
   uint64 count = 2;
 }
 
-// GenerateIdentifiersResponse for a specific application.
+// GenerateIdentifiersResponse contains generated identifiers and service
+// metadata.
 message GenerateIdentifiersResponse {
+  // meta contains service and transport metadata. It is reserved for
+  // infrastructure metadata and is not business data.
   map<string, string> meta = 1;
+
+  // ids contains the generated identifiers.
   repeated string ids = 2;
 }
 
-// MapIdentifiersRequest for some identifiers.
+// MapIdentifiersRequest asks the service to map identifiers through the
+// configured mapper table.
 message MapIdentifiersRequest {
+  // ids contains the identifiers to map.
+  //
+  // The maximum accepted list length is 1000. Larger requests fail with
+  // InvalidArgument. Mapping is strict: if mapper configuration is omitted, or
+  // if any identifier is absent from the mapper table, MapIdentifiers fails
+  // with NotFound.
   repeated string ids = 1;
 }
 
-// MapIdentifiersResponse for some identifiers.
+// MapIdentifiersResponse contains mapped identifiers and service metadata.
 message MapIdentifiersResponse {
+  // meta contains service and transport metadata. It is reserved for
+  // infrastructure metadata and is not business data.
   map<string, string> meta = 1;
+
+  // ids contains mapped identifiers in the same order as the request ids.
   repeated string ids = 2;
 }
 
-// Service allows to manage identifiers.
+// Service generates and maps identifiers.
 service Service {
-  // GenerateIdentifiers for a specific application.
+  // GenerateIdentifiers generates identifiers for a configured application.
+  //
+  // It returns InvalidArgument when count exceeds 1000, and NotFound when the
+  // application or generator kind cannot be resolved.
   rpc GenerateIdentifiers(GenerateIdentifiersRequest) returns (GenerateIdentifiersResponse) {}
 
-  // MapIdentifiers for some identifiers.
+  // MapIdentifiers maps identifiers through the configured mapper table.
+  //
+  // It returns InvalidArgument when more than 1000 identifiers are requested,
+  // and NotFound when mapper configuration is omitted or any requested
+  // identifier is absent from the table.
   rpc MapIdentifiers(MapIdentifiersRequest) returns (MapIdentifiersResponse) {}
 }

--- a/api/bezeichner/v1/service_grpc.pb.go
+++ b/api/bezeichner/v1/service_grpc.pb.go
@@ -27,11 +27,18 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 //
-// Service allows to manage identifiers.
+// Service generates and maps identifiers.
 type ServiceClient interface {
-	// GenerateIdentifiers for a specific application.
+	// GenerateIdentifiers generates identifiers for a configured application.
+	//
+	// It returns InvalidArgument when count exceeds 1000, and NotFound when the
+	// application or generator kind cannot be resolved.
 	GenerateIdentifiers(ctx context.Context, in *GenerateIdentifiersRequest, opts ...grpc.CallOption) (*GenerateIdentifiersResponse, error)
-	// MapIdentifiers for some identifiers.
+	// MapIdentifiers maps identifiers through the configured mapper table.
+	//
+	// It returns InvalidArgument when more than 1000 identifiers are requested,
+	// and NotFound when mapper configuration is omitted or any requested
+	// identifier is absent from the table.
 	MapIdentifiers(ctx context.Context, in *MapIdentifiersRequest, opts ...grpc.CallOption) (*MapIdentifiersResponse, error)
 }
 
@@ -67,11 +74,18 @@ func (c *serviceClient) MapIdentifiers(ctx context.Context, in *MapIdentifiersRe
 // All implementations must embed UnimplementedServiceServer
 // for forward compatibility.
 //
-// Service allows to manage identifiers.
+// Service generates and maps identifiers.
 type ServiceServer interface {
-	// GenerateIdentifiers for a specific application.
+	// GenerateIdentifiers generates identifiers for a configured application.
+	//
+	// It returns InvalidArgument when count exceeds 1000, and NotFound when the
+	// application or generator kind cannot be resolved.
 	GenerateIdentifiers(context.Context, *GenerateIdentifiersRequest) (*GenerateIdentifiersResponse, error)
-	// MapIdentifiers for some identifiers.
+	// MapIdentifiers maps identifiers through the configured mapper table.
+	//
+	// It returns InvalidArgument when more than 1000 identifiers are requested,
+	// and NotFound when mapper configuration is omitted or any requested
+	// identifier is absent from the table.
 	MapIdentifiers(context.Context, *MapIdentifiersRequest) (*MapIdentifiersResponse, error)
 	mustEmbedUnimplementedServiceServer()
 }

--- a/internal/api/ids/doc.go
+++ b/internal/api/ids/doc.go
@@ -25,15 +25,16 @@
 // Map depends on mapper configuration (see internal/mapper):
 //
 // The mapper configuration provides a lookup table from input identifier to mapped
-// identifier. If any input identifier is missing, the operation returns ErrNotFound.
+// identifier. If mapper configuration is omitted, or if any input identifier is
+// missing, the operation returns ErrNotFound.
 //
 // # Errors
 //
 // The domain layer defines two primary error categories:
 //
 //   - ErrInvalidArgument: returned when request limits are exceeded.
-//   - ErrNotFound: returned when a requested application, generator kind, or mapping
-//     entry cannot be found.
+//   - ErrNotFound: returned when a requested application, generator kind,
+//     mapper configuration, or mapping entry cannot be found.
 //
 // Helper predicates are provided to classify errors when needed. Transports are
 // expected to map these error categories to their protocol-specific equivalents

--- a/internal/api/ids/ids.go
+++ b/internal/api/ids/ids.go
@@ -71,12 +71,14 @@ func (s *Identifier) Generate(ctx context.Context, application string, count uin
 
 // Map returns the mapped identifiers for the provided ids in the same order.
 //
-// Mapping is configured via mapper configuration. If any input identifier is
-// missing from the mapping table, the operation fails.
+// Mapping is configured via mapper configuration. If mapper configuration is
+// omitted, or if any input identifier is missing from the mapping table, the
+// operation fails.
 //
 // Errors:
 //   - ErrInvalidArgument if len(ids) exceeds the configured limit.
-//   - ErrNotFound if any input identifier does not have a configured mapping.
+//   - ErrNotFound if mapper configuration is omitted or any input identifier
+//     does not have a configured mapping.
 func (s *Identifier) Map(ids []string) ([]string, error) {
 	if len(ids) > maxMapIDs {
 		return nil, ErrInvalidArgument

--- a/internal/api/v1/transport/grpc/doc.go
+++ b/internal/api/v1/transport/grpc/doc.go
@@ -11,6 +11,7 @@
 // The transport maps domain errors to gRPC codes as follows:
 //   - ids.ErrInvalidArgument -> codes.InvalidArgument
 //   - ids.ErrNotFound        -> codes.NotFound
+//   - all other non-nil domain errors currently fall back to codes.NotFound
 //
 // Callers should rely on these status codes (rather than parsing message text) for
 // programmatic behavior.

--- a/internal/cmd/doc.go
+++ b/internal/cmd/doc.go
@@ -11,8 +11,8 @@
 // package-level Module, which composes all required sub-modules.
 //
 // The server is intended to be run by providing configuration via the standard
-// go-service mechanisms (for example, using the "-i" flag to point at a config
-// file). See internal/config for the configuration schema.
+// go-service mechanisms (for example, using "-config file:<path>" to point at a
+// config file). See internal/config for the configuration schema.
 //
 // This package does not implement business logic. Domain behavior lives in
 // internal/api/ids, and transport bindings are wired under internal/api/v1.

--- a/internal/generator/doc.go
+++ b/internal/generator/doc.go
@@ -40,7 +40,7 @@
 //   - "xid":       XID string
 //   - "snowflake": Sonyflake-based numeric ID (decimal string)
 //   - "nanoid":    NanoID string
-//   - "typeid":    TypeID string
+//   - "typeid":    prefixless TypeID string
 //
 // # Errors
 //

--- a/internal/generator/typeid.go
+++ b/internal/generator/typeid.go
@@ -8,7 +8,7 @@ import (
 // TypeID generator.
 type TypeID struct{}
 
-// Generate a TypeID.
+// Generate a prefixless TypeID.
 func (t *TypeID) Generate(_ context.Context, _ *Application) string {
 	return typeid.Must(typeid.WithPrefix("")).String()
 }

--- a/internal/mapper/doc.go
+++ b/internal/mapper/doc.go
@@ -17,9 +17,10 @@
 // The domain operation that performs mapping preserves order: it returns outputs
 // in the same order as the input slice.
 //
-// Mapping is strict: if any input identifier does not exist in the table, the
-// operation fails with a "not found" error from the domain layer. This prevents
-// silently returning partial results.
+// Mapper configuration is optional at service startup, but mapping still
+// requires it. If mapper configuration is omitted, or if any input identifier
+// does not exist in the table, the operation fails with a "not found" error
+// from the domain layer. This prevents silently returning partial results.
 //
 // # Size limits
 //

--- a/test/.config/server.yml
+++ b/test/.config/server.yml
@@ -23,6 +23,8 @@ generator:
       kind: nanoid
     - name: typeid
       kind: typeid
+    # Negative fixture: this application is intentionally configured with an
+    # unresolved kind so API tests can assert NotFound behavior.
     - name: invalid_kind
       kind: invalid_kind
 health:

--- a/test/features/v1/transport/grpc/api.feature
+++ b/test/features/v1/transport/grpc/api.feature
@@ -37,8 +37,8 @@ Feature: gRPC API
 
   Scenario: Generate too many identifiers for existing applications
     When I request to generate identifiers with gRPC:
-      | application | <application> |
-      | count       |          1001 |
+      | application | uuid |
+      | count       | 1001 |
     Then I should receive an invalid argument error from gRPC
 
   Scenario Outline: Generate identifiers for missing applications

--- a/test/features/v1/transport/http/api.feature
+++ b/test/features/v1/transport/http/api.feature
@@ -37,8 +37,8 @@ Feature: HTTP API
 
   Scenario: Generate too many identifiers for existing applications
     When I request to generate identifiers with HTTP:
-      | application | <application> |
-      | count       |          1001 |
+      | application | uuid |
+      | count       | 1001 |
     Then I should receive an invalid argument error from HTTP
 
   Scenario Outline: Generate identifiers for missing applications

--- a/test/lib/bezeichner.rb
+++ b/test/lib/bezeichner.rb
@@ -94,7 +94,7 @@ module Bezeichner
       # @return [Bezeichner::V1::HTTP]
       #
       # @example Generate identifiers over HTTP
-      #   Bezeichner::V1.http.generate('public-uuid', 3)
+      #   Bezeichner::V1.http.generate('uuid', 3)
       def http
         @http ||= Bezeichner::V1::HTTP.new('http://localhost:11000')
       end
@@ -104,7 +104,7 @@ module Bezeichner
       # @return [Bezeichner::V1::Service::Stub]
       #
       # @example Generate identifiers over gRPC
-      #   req = Bezeichner::V1::GenerateIdentifiersRequest.new(application: 'public-uuid', count: 3)
+      #   req = Bezeichner::V1::GenerateIdentifiersRequest.new(application: 'uuid', count: 3)
       #   Bezeichner::V1.grpc.generate_identifiers(req)
       def grpc
         @grpc ||= Bezeichner::V1::Service::Stub.new('localhost:12000', :this_channel_is_insecure, channel_args: Bezeichner.user_agent)

--- a/test/lib/bezeichner/v1/http.rb
+++ b/test/lib/bezeichner/v1/http.rb
@@ -38,8 +38,8 @@ module Bezeichner
       # @param opts [Hash] options forwarded to {Nonnative::HTTPClient#post}
       # @return [Object] HTTP response as returned by {Nonnative::HTTPClient#post}
       #
-      # @example Generate three UUID identifiers for application "public-uuid"
-      #   Bezeichner::V1.http.generate('public-uuid', 3)
+      # @example Generate three UUID identifiers for application "uuid"
+      #   Bezeichner::V1.http.generate('uuid', 3)
       def generate(application, count, opts = {})
         post('/bezeichner.v1.Service/GenerateIdentifiers', { application:, count: }.to_json, opts)
       end
@@ -51,7 +51,7 @@ module Bezeichner
       # @return [Object] HTTP response as returned by {Nonnative::HTTPClient#post}
       #
       # @example Map identifiers using the configured mapping table
-      #   Bezeichner::V1.http.map(%w[legacy-1 legacy-2])
+      #   Bezeichner::V1.http.map(%w[req1 req2])
       def map(ids, opts = {})
         post('/bezeichner.v1.Service/MapIdentifiers', { ids: }.to_json, opts)
       end

--- a/test/lib/bezeichner/v1/service_services_pb.rb
+++ b/test/lib/bezeichner/v1/service_services_pb.rb
@@ -7,7 +7,7 @@ require 'bezeichner/v1/service_pb'
 module Bezeichner
   module V1
     module Service
-      # Service allows to manage identifiers.
+      # Service generates and maps identifiers.
       class Service
 
         include ::GRPC::GenericService
@@ -16,9 +16,16 @@ module Bezeichner
         self.unmarshal_class_method = :decode
         self.service_name = 'bezeichner.v1.Service'
 
-        # GenerateIdentifiers for a specific application.
+        # GenerateIdentifiers generates identifiers for a configured application.
+        #
+        # It returns InvalidArgument when count exceeds 1000, and NotFound when the
+        # application or generator kind cannot be resolved.
         rpc :GenerateIdentifiers, ::Bezeichner::V1::GenerateIdentifiersRequest, ::Bezeichner::V1::GenerateIdentifiersResponse
-        # MapIdentifiers for some identifiers.
+        # MapIdentifiers maps identifiers through the configured mapper table.
+        #
+        # It returns InvalidArgument when more than 1000 identifiers are requested,
+        # and NotFound when mapper configuration is omitted or any requested
+        # identifier is absent from the table.
         rpc :MapIdentifiers, ::Bezeichner::V1::MapIdentifiersRequest, ::Bezeichner::V1::MapIdentifiersResponse
       end
 


### PR DESCRIPTION
## What

- Expanded the protobuf service contract and regenerated Go/Ruby stubs so generated clients include request limits, NotFound/InvalidArgument behavior, metadata ownership, and map ordering.
- Aligned README, AGENTS, GoDoc, and Ruby examples with current configuration flags, mapper behavior, TypeID output, submodule setup, and CI/protobuf workflow.
- Cleaned API feature examples and test config comments so fixtures document their intended positive and negative coverage.

## Why

- Prevents users, maintainers, and generated-client consumers from relying on stale setup commands or underspecified API/configuration behavior.
- Puts the service contract in the places reviewers and clients actually read: proto comments, README/AGENTS, GoDoc, RDoc, and feature fixtures.

## Testing

- `make proto-lint` - passed
- `make proto-generate` - passed
- `git diff --check` - passed
- `make lint` - passed
- `make specs` - passed
- `make features` - passed
- `make proto-stale` - not run pre-commit because it requires a clean working tree after generation; `make proto-generate` refreshed generated outputs, and CI runs `make proto-stale` after checkout.

AI-assisted-by: [Codex](https://openai.com/codex/)
