### PR TITLE
docs(readme): clarify configuration contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ Bezeichner uses the `go-service` configuration conventions. A representative con
 > [!TIP]
 > Use `test/.config/server.yml` as the copy-paste source for local examples. The usage examples below use application and mapping names from that file.
 
+Startup requires the top-level `health` and `generator` blocks. The `mapper`
+block is optional, but omitting it makes every `MapIdentifiers` request fail
+with `NotFound`.
+
 ### 🧬 Generator configuration
 
 Generator configuration selects **applications**, each of which has:
@@ -63,12 +67,12 @@ validation during startup.
 
 Supported built-in kinds (at time of writing):
 
-- `uuid`
-- `ksuid`
-- `ulid`
-- `xid`
-- `snowflake`
-- `nanoid`
+- `uuid` (UUIDv7 string)
+- `ksuid` (KSUID string)
+- `ulid` (ULID string)
+- `xid` (XID string)
+- `snowflake` (Sonyflake-based numeric ID as a decimal string)
+- `nanoid` (NanoID string)
 - `typeid` (prefixless TypeID string; prefix configuration is not currently exposed)
 
 Example:
@@ -107,6 +111,8 @@ health:
   timeout:  1s   # max time a single check may take
 ```
 
+Both values must be positive durations.
+
 The service registers:
 
 - `noop` and `online` checks.
@@ -116,7 +122,14 @@ service convention that all services should report whether they can reach the
 outside world if they need public egress later, even when the current generate
 and map paths do not require outbound network access.
 
-The service exposes health observers for HTTP (`healthz`, `livez`, `readyz`) and gRPC health checks.
+The service exposes these health observers:
+
+| Observer | Check |
+| --- | --- |
+| HTTP `healthz` | `online` |
+| HTTP `livez` | `noop` |
+| HTTP `readyz` | `noop` |
+| gRPC health | `noop` |
 
 ## 🚀 Running
 

--- a/internal/api/ids/doc.go
+++ b/internal/api/ids/doc.go
@@ -10,8 +10,8 @@
 //   - Generate: produce one or more identifiers for a named application.
 //   - Map: map a list of existing identifiers to their configured replacements.
 //
-// Both operations enforce request-size limits as a simple DoS-protection mechanism.
-// When limits are exceeded, Generate/Map return ErrInvalidArgument.
+// Both operations enforce fixed request-size limits as a simple DoS-protection
+// mechanism. When limits are exceeded, Generate/Map return ErrInvalidArgument.
 //
 // # Configuration
 //
@@ -24,9 +24,9 @@
 //
 // Map depends on mapper configuration (see internal/mapper):
 //
-// The mapper configuration provides a lookup table from input identifier to mapped
-// identifier. If mapper configuration is omitted, or if any input identifier is
-// missing, the operation returns ErrNotFound.
+// The optional mapper configuration provides a lookup table from input identifier
+// to mapped identifier. If mapper configuration is omitted, or if any input
+// identifier is missing, the operation returns ErrNotFound.
 //
 // # Errors
 //
@@ -36,7 +36,7 @@
 //   - ErrNotFound: returned when a requested application, generator kind,
 //     mapper configuration, or mapping entry cannot be found.
 //
-// Helper predicates are provided to classify errors when needed. Transports are
-// expected to map these error categories to their protocol-specific equivalents
-// (e.g., gRPC codes InvalidArgument and NotFound).
+// Use IsInvalidArgument to classify ErrInvalidArgument without relying on error
+// strings. Transports are expected to map these error categories to their
+// protocol-specific equivalents (e.g., gRPC codes InvalidArgument and NotFound).
 package ids

--- a/internal/api/ids/ids.go
+++ b/internal/api/ids/ids.go
@@ -21,8 +21,10 @@ var ErrNotFound = errors.New("not found")
 //
 // It requires:
 //   - generator configuration (to resolve an application by name),
-//   - mapper configuration (to map identifiers),
 //   - and a generator registry (to resolve a generator by application kind).
+//
+// Mapper configuration is optional. When it is omitted, Map returns ErrNotFound
+// for every request.
 func NewIdentifier(gc *generator.Config, mc *mapper.Config, gs generator.Generators) *Identifier {
 	return &Identifier{generatorConfig: gc, mapperConfig: mc, generators: gs}
 }
@@ -43,7 +45,7 @@ type Identifier struct {
 // generator kind used to produce each identifier.
 //
 // Errors:
-//   - ErrInvalidArgument if count exceeds the configured limit.
+//   - ErrInvalidArgument if count exceeds the fixed domain limit.
 //   - ErrNotFound if the application name does not exist, or if the application
 //     kind cannot be resolved to a generator.
 func (s *Identifier) Generate(ctx context.Context, application string, count uint64) ([]string, error) {
@@ -76,7 +78,7 @@ func (s *Identifier) Generate(ctx context.Context, application string, count uin
 // operation fails.
 //
 // Errors:
-//   - ErrInvalidArgument if len(ids) exceeds the configured limit.
+//   - ErrInvalidArgument if len(ids) exceeds the fixed domain limit.
 //   - ErrNotFound if mapper configuration is omitted or any input identifier
 //     does not have a configured mapping.
 func (s *Identifier) Map(ids []string) ([]string, error) {

--- a/internal/api/ids/limits.go
+++ b/internal/api/ids/limits.go
@@ -9,7 +9,7 @@ const (
 
 // ErrInvalidArgument indicates the caller supplied an invalid request.
 //
-// In this package it is returned when a request exceeds the configured limits,
+// In this package it is returned when a request exceeds the fixed domain limits,
 // for example an excessive generate count or too many IDs to map.
 //
 // Use IsInvalidArgument to classify errors without relying on error strings.

--- a/internal/config/doc.go
+++ b/internal/config/doc.go
@@ -19,6 +19,10 @@
 //
 // and embeds *go-service/v2/config.Config for common service settings.
 //
+// Health and generator configuration are required at startup. Mapper
+// configuration is optional; when omitted, mapping requests fail with the domain
+// ErrNotFound error.
+//
 // # Dependency injection
 //
 // The package-level Module wires configuration loading and provides constructors


### PR DESCRIPTION
## What

- Document required startup configuration, optional mapper behavior, generator output formats, and health observer bindings in the README.
- Align internal GoDoc with the domain contracts for fixed request limits, optional mapper configuration, and error classification.

## Why

- The docs now make startup validation, probe behavior, and generator selection clearer for users, operators, and maintainers.
- The internal comments no longer imply runtime-configurable request caps, mandatory mapper wiring, or helper predicates that do not exist.

## Testing

- `make lint` - passed
- `git diff --check` - passed
