### PR TITLE
docs(readme): clarify identifier service contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,7 +150,8 @@ A representative config used by dev/feature tests is `test/.config/server.yml`.
 Notable keys observed:
 - `generator.applications[]`: generator applications (**name** and **kind**).
 - `mapper.identifiers`: mapping table for `MapIdentifiers`.
-- `transport.http.address` defaults to `tcp://:11000` and `transport.grpc.address` to `tcp://:12000`.
+- The representative test config sets `transport.http.address` to
+  `tcp://:11000` and `transport.grpc.address` to `tcp://:12000`.
 
 Notes:
 - The generator application model in code currently includes only `name` and `kind` (no `prefix`, `suffix`, or `separator` fields).
@@ -234,7 +235,12 @@ cd test && bundle pristine json
 
 ## CI notes (CircleCI)
 
-CircleCI runs (see `.circleci/config.yml`):
+The primary CircleCI `build-service` job runs (see `.circleci/config.yml`):
 
 - `make dep`, `make lint`, `make proto-breaking`, `make proto-stale`, `make sec`
 - `make features`, `make benchmarks`, `make analyse`, `make coverage`, `make codecov-upload`
+
+The workflow also runs Docker image validation on non-master branches:
+
+- `make platform=amd64 test-docker`
+- `make platform=arm64 test-docker`

--- a/README.md
+++ b/README.md
@@ -131,6 +131,17 @@ The service exposes these health observers:
 | HTTP `readyz` | `noop` |
 | gRPC health | `noop` |
 
+With the sample config, operational HTTP routes are service-prefixed:
+
+| Endpoint | Local path |
+| --- | --- |
+| Health | `/bezeichner/healthz` |
+| Liveness | `/bezeichner/livez` |
+| Readiness | `/bezeichner/readyz` |
+| Prometheus metrics | `/bezeichner/metrics` |
+
+The gRPC health service name is `bezeichner.v1.Service`.
+
 ## 🚀 Running
 
 ### ♻️ Local dev (hot reload)
@@ -194,7 +205,7 @@ Generate identifiers:
 curl -sS \
   -X POST \
   -H 'content-type: application/json' \
-  --data '{"application":"uuid","count":"3"}' \
+  --data '{"application":"uuid","count":3}' \
   http://localhost:11000/bezeichner.v1.Service/GenerateIdentifiers
 ```
 
@@ -218,6 +229,10 @@ Bezeichner is typically deployed as a shared internal service. Depending on your
 - run a single global instance,
 - shard by bounded context,
 - run per region/cluster.
+
+Published Docker images use the `alexfalkowski/bezeichner` repository. Pin a
+released version tag such as `alexfalkowski/bezeichner:<version>` for
+deployments.
 
 > [!CAUTION]
 > The `snowflake` generator uses Sonyflake defaults. The intended deployment assumes normal Kubernetes pod networking where each concurrently running pod has a suitable private IPv4-derived machine ID. Re-evaluate that assumption for local multi-process deployments, `hostNetwork`, overlapping pod CIDRs, multi-cluster shared ID spaces, IPv6-only environments, or environments without private IPv4 addresses.
@@ -279,4 +294,10 @@ End-to-end feature tests:
 
 ```sh
 make features
+```
+
+End-to-end benchmark scenarios:
+
+```sh
+make benchmarks
 ```

--- a/api/bezeichner/v1/service.pb.go
+++ b/api/bezeichner/v1/service.pb.go
@@ -32,6 +32,9 @@ type GenerateIdentifiersRequest struct {
 	Application string `protobuf:"bytes,1,opt,name=application,proto3" json:"application,omitempty"`
 	// count is the number of identifiers to generate.
 	//
+	// A zero value is valid when application resolves and returns an empty ids
+	// list.
+	//
 	// The maximum accepted count is 1000. Larger requests fail with
 	// InvalidArgument.
 	Count         uint64 `protobuf:"varint,2,opt,name=count,proto3" json:"count,omitempty"`
@@ -89,6 +92,9 @@ type GenerateIdentifiersResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// meta contains service and transport metadata. It is reserved for
 	// infrastructure metadata and is not business data.
+	//
+	// Bezeichner currently returns requestId and userAgent when the transport
+	// can derive them from request metadata.
 	Meta map[string]string `protobuf:"bytes,1,rep,name=meta,proto3" json:"meta,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	// ids contains the generated identifiers.
 	Ids           []string `protobuf:"bytes,2,rep,name=ids,proto3" json:"ids,omitempty"`
@@ -146,6 +152,10 @@ type MapIdentifiersRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// ids contains the identifiers to map.
 	//
+	// An empty list is valid when mapper configuration is present and returns an
+	// empty ids list. If mapper configuration is omitted, MapIdentifiers fails
+	// with NotFound before mapping.
+	//
 	// The maximum accepted list length is 1000. Larger requests fail with
 	// InvalidArgument. Mapping is strict: if mapper configuration is omitted, or
 	// if any identifier is absent from the mapper table, MapIdentifiers fails
@@ -197,6 +207,9 @@ type MapIdentifiersResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// meta contains service and transport metadata. It is reserved for
 	// infrastructure metadata and is not business data.
+	//
+	// Bezeichner currently returns requestId and userAgent when the transport
+	// can derive them from request metadata.
 	Meta map[string]string `protobuf:"bytes,1,rep,name=meta,proto3" json:"meta,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	// ids contains mapped identifiers in the same order as the request ids.
 	Ids           []string `protobuf:"bytes,2,rep,name=ids,proto3" json:"ids,omitempty"`

--- a/api/bezeichner/v1/service.proto
+++ b/api/bezeichner/v1/service.proto
@@ -16,6 +16,9 @@ message GenerateIdentifiersRequest {
 
   // count is the number of identifiers to generate.
   //
+  // A zero value is valid when application resolves and returns an empty ids
+  // list.
+  //
   // The maximum accepted count is 1000. Larger requests fail with
   // InvalidArgument.
   uint64 count = 2;
@@ -26,6 +29,9 @@ message GenerateIdentifiersRequest {
 message GenerateIdentifiersResponse {
   // meta contains service and transport metadata. It is reserved for
   // infrastructure metadata and is not business data.
+  //
+  // Bezeichner currently returns requestId and userAgent when the transport
+  // can derive them from request metadata.
   map<string, string> meta = 1;
 
   // ids contains the generated identifiers.
@@ -36,6 +42,10 @@ message GenerateIdentifiersResponse {
 // configured mapper table.
 message MapIdentifiersRequest {
   // ids contains the identifiers to map.
+  //
+  // An empty list is valid when mapper configuration is present and returns an
+  // empty ids list. If mapper configuration is omitted, MapIdentifiers fails
+  // with NotFound before mapping.
   //
   // The maximum accepted list length is 1000. Larger requests fail with
   // InvalidArgument. Mapping is strict: if mapper configuration is omitted, or
@@ -48,6 +58,9 @@ message MapIdentifiersRequest {
 message MapIdentifiersResponse {
   // meta contains service and transport metadata. It is reserved for
   // infrastructure metadata and is not business data.
+  //
+  // Bezeichner currently returns requestId and userAgent when the transport
+  // can derive them from request metadata.
   map<string, string> meta = 1;
 
   // ids contains mapped identifiers in the same order as the request ids.

--- a/internal/api/ids/ids.go
+++ b/internal/api/ids/ids.go
@@ -44,6 +44,9 @@ type Identifier struct {
 // The application is resolved from generator configuration and selects the
 // generator kind used to produce each identifier.
 //
+// A count of zero is valid and returns an empty slice when the application and
+// generator kind can be resolved.
+//
 // Errors:
 //   - ErrInvalidArgument if count exceeds the fixed domain limit.
 //   - ErrNotFound if the application name does not exist, or if the application
@@ -76,6 +79,9 @@ func (s *Identifier) Generate(ctx context.Context, application string, count uin
 // Mapping is configured via mapper configuration. If mapper configuration is
 // omitted, or if any input identifier is missing from the mapping table, the
 // operation fails.
+//
+// An empty ids slice is valid and returns an empty slice when mapper
+// configuration is present.
 //
 // Errors:
 //   - ErrInvalidArgument if len(ids) exceeds the fixed domain limit.

--- a/internal/api/v1/transport/http/doc.go
+++ b/internal/api/v1/transport/http/doc.go
@@ -23,5 +23,8 @@
 //
 // Since the HTTP gateway delegates directly to the gRPC handlers, error
 // semantics and classification originate from the gRPC transport's mapping
-// of domain errors to status codes.
+// of domain errors to status codes. The HTTP layer then renders those
+// classifications as HTTP statuses; for this API, InvalidArgument becomes
+// HTTP 400 and NotFound becomes HTTP 404. Error bodies are written as safe
+// plain-text messages using the go-service "text/error" media type.
 package http

--- a/internal/generator/snowflake.go
+++ b/internal/generator/snowflake.go
@@ -8,19 +8,26 @@ import (
 	"github.com/sony/sonyflake"
 )
 
-// Snowflake generator.
+// Snowflake generates Sonyflake IDs using Sonyflake default settings.
+//
+// The defaults derive the machine ID from a private IPv4 address.
 type Snowflake struct {
 	sf *sonyflake.Sonyflake
 }
 
-// NewSnowflake generator.
+// NewSnowflake constructs a Snowflake generator with Sonyflake default settings.
+//
+// Sonyflake's constructor can return nil when the default machine ID cannot be
+// derived, such as in environments without a private IPv4 address. In that
+// case, Generate will panic when it attempts to use the nil Sonyflake instance.
 func NewSnowflake() *Snowflake {
 	return &Snowflake{sf: sonyflake.NewSonyflake(sonyflake.Settings{})}
 }
 
 // Generate a Snowflake ID.
 //
-// If Sonyflake's time range is exhausted, this method panics via [runtime.Must].
+// Generate panics if Sonyflake construction failed or if Sonyflake's time range
+// is exhausted.
 func (s *Snowflake) Generate(_ context.Context, _ *Application) string {
 	id, err := s.sf.NextID()
 	runtime.Must(err)

--- a/test/lib/bezeichner/v1/http.rb
+++ b/test/lib/bezeichner/v1/http.rb
@@ -24,7 +24,13 @@ module Bezeichner
     # - {Bezeichner::V1::MapIdentifiersRequest}
     #
     # The response bodies match the protobuf response messages and may include `meta`
-    # (observability metadata) depending on server behavior.
+    # (`requestId` and `userAgent` observability metadata) depending on server behavior.
+    #
+    # ## Error responses
+    #
+    # The HTTP gateway uses the gRPC handler error mapping and renders errors as HTTP
+    # status responses. `InvalidArgument` is returned as HTTP 400, `NotFound` as HTTP
+    # 404, and safe error messages are returned as `text/error` bodies.
     #
     # ## Options
     #
@@ -34,7 +40,7 @@ module Bezeichner
       # Calls GenerateIdentifiers over HTTP.
       #
       # @param application [String] configured generator application name
-      # @param count [Integer] number of identifiers to generate
+      # @param count [Integer] number of identifiers to generate; zero returns no IDs
       # @param opts [Hash] options forwarded to {Nonnative::HTTPClient#post}
       # @return [Object] HTTP response as returned by {Nonnative::HTTPClient#post}
       #
@@ -46,7 +52,7 @@ module Bezeichner
 
       # Calls MapIdentifiers over HTTP.
       #
-      # @param ids [Array<String>] identifiers to map
+      # @param ids [Array<String>] identifiers to map; an empty list returns no IDs when mapper configuration is present
       # @param opts [Hash] options forwarded to {Nonnative::HTTPClient#post}
       # @return [Object] HTTP response as returned by {Nonnative::HTTPClient#post}
       #


### PR DESCRIPTION
## What

- Clarify Bezeichner API and operator documentation found during the doc-gap pass.
- Correct the HTTP curl generate example to send JSON count as a number.
- Document operational health and metrics paths, gRPC health service name, Docker image tagging, benchmark workflow, response metadata keys, zero/empty request behavior, HTTP gateway errors, and Snowflake default-machine-ID behavior.
- Update generated Go protobuf comments from the service proto.

## Why

- Prevent API clients from copying an HTTP JSON example that can fail request decoding before the service handler runs.
- Give operators enough concrete path and artifact information to configure probes, metrics scraping, and pinned Docker deployments without reverse-engineering test harness or release tooling.
- Keep public API comments and maintainer guidance aligned with behavior that is already enforced or asserted by the service and feature tests.

## Testing

- `make proto-generate` - passed
- `make proto-lint` - passed
- `make lint` - passed
- `git diff --check` - passed
- `make proto-stale` - not run to completion locally because the target reruns generation and then fails on the intentionally dirty worktree diff; generated output is included in this change.
- `make features` - failed during local nonnative startup timeout after starting the server; no Bezeichner process was left running.

AI-assisted-by: [Codex](https://openai.com/codex/)
