### PR TITLE
test(feature): centralize http request options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ vendor
 dist
 .source-key
 ISSUES.md
+FEATURES.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,14 @@ Notes:
 - `main_test.go` is guarded by build tag `features` (`main_test.go:1-10`).
 - `make features` depends on `make build-test` (see `bin/build/make/_service.mak:100-102`).
 
+### Local CI preflight target belongs in shared bin tooling
+
+- This repository consumes shared Make targets from the `bin/` submodule.
+- If a one-command local CI preflight target is needed, it should be added to
+  the shared `bin` Make fragments rather than as a service-local target here.
+- Reviewers should not flag the lack of a root `verify`/`ci-checks` target in
+  this repository as a feature gap by default.
+
 ### Lint / format / security
 
 ```sh
@@ -208,6 +216,16 @@ These surface to clients as `InvalidArgument` via the gRPC error mapper (`intern
 - Harness config: `test/nonnative.yml`.
   - Launches `../bezeichner server -config file:.config/server.yml` (`test/nonnative.yml:6-12`).
 - Cucumber report options: `test/.config/cucumber.yml:1`.
+
+### Ruby feature harness endpoints are local by design
+
+- The Ruby code under `test/` is a local feature-test harness, not production
+  service code.
+- Fixed localhost endpoints in `test/lib/**`, `test/nonnative.yml`, and related
+  feature helpers are intentional local harness assumptions unless there is
+  concrete evidence of current workflow breakage.
+- Reviewers should not flag the lack of environment-configurable HTTP, gRPC, or
+  observability endpoints as a feature gap by default.
 
 If bundler fails loading native gems (e.g., `json` extension), one observed fix is rebuilding the gem:
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,1 +1,2 @@
+include ../bin/build/make/help.mak
 include ../bin/build/make/ruby.mak

--- a/test/features/step_definitions/health/transport/http/observability_steps.rb
+++ b/test/features/step_definitions/health/transport/http/observability_steps.rb
@@ -1,12 +1,7 @@
 # frozen_string_literal: true
 
 When('the system requests the {string} with HTTP') do |name|
-  opts = {
-    headers: { request_id: SecureRandom.uuid },
-    read_timeout: 10, open_timeout: 10
-  }
-
-  @response = Nonnative.observability.send(name, opts)
+  @response = Nonnative.observability.send(name, Bezeichner.http_options)
 end
 
 Then('the system should respond with a healthy status with HTTP') do

--- a/test/features/step_definitions/v1/transport/http/api_steps.rb
+++ b/test/features/step_definitions/v1/transport/http/api_steps.rb
@@ -3,13 +3,12 @@
 When('I request to generate identifiers with HTTP:') do |table|
   rows = table.rows_hash
   @request_id = SecureRandom.uuid
-  opts = {
+  opts = Bezeichner.http_options(
     headers: {
       request_id: @request_id, user_agent: 'Bezeichner-ruby-client/1.0 HTTP/1.0',
       content_type: :json, accept: :json
-    },
-    read_timeout: 10, open_timeout: 10
-  }
+    }
+  )
 
   @response = Bezeichner::V1.http.generate(rows['application'], rows['count'].to_i, opts)
 end
@@ -17,39 +16,36 @@ end
 When('I request to map identifiers with HTTP:') do |table|
   rows = table.rows_hash
   @request_id = SecureRandom.uuid
-  opts = {
+  opts = Bezeichner.http_options(
     headers: {
       request_id: @request_id, user_agent: 'Bezeichner-ruby-client/1.0 HTTP/1.0',
       content_type: :json, accept: :json
-    },
-    read_timeout: 10, open_timeout: 10
-  }
+    }
+  )
 
   @response = Bezeichner::V1.http.map(rows['request'].split(','), opts)
 end
 
 When('I request to map {int} identifiers with HTTP:') do |count|
   @request_id = SecureRandom.uuid
-  opts = {
+  opts = Bezeichner.http_options(
     headers: {
       request_id: @request_id, user_agent: 'Bezeichner-ruby-client/1.0 HTTP/1.0',
       content_type: :json, accept: :json
-    },
-    read_timeout: 10, open_timeout: 10
-  }
+    }
+  )
 
   @response = Bezeichner::V1.http.map(count.times.map { SecureRandom.hex }, opts)
 end
 
 When('I request to map {int} existing identifiers with HTTP') do |count|
   @request_id = SecureRandom.uuid
-  opts = {
+  opts = Bezeichner.http_options(
     headers: {
       request_id: @request_id, user_agent: 'Bezeichner-ruby-client/1.0 HTTP/1.0',
       content_type: :json, accept: :json
-    },
-    read_timeout: 10, open_timeout: 10
-  }
+    }
+  )
 
   @response = Bezeichner::V1.http.map(Array.new(count, 'req1'), opts)
 end

--- a/test/features/step_definitions/v1/transport/http/benchmark_steps.rb
+++ b/test/features/step_definitions/v1/transport/http/benchmark_steps.rb
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
 When('I request to generate identifiers with HTTP which performs in {int} ms') do |time|
-  opts = {
+  opts = Bezeichner.http_options(
     headers: {
-      request_id: SecureRandom.uuid, user_agent: 'Bezeichner-ruby-client/1.0 HTTP/1.0',
+      user_agent: 'Bezeichner-ruby-client/1.0 HTTP/1.0',
       content_type: :json, accept: :json
-    },
-    read_timeout: 10, open_timeout: 10
-  }
+    }
+  )
 
   expect { Bezeichner::V1.http.generate('ulid', 2, opts) }.to perform_under(time).ms
 end

--- a/test/lib/bezeichner.rb
+++ b/test/lib/bezeichner.rb
@@ -72,6 +72,24 @@ module Bezeichner
       }
     end
 
+    # Returns bounded per-call options for HTTP feature-harness requests.
+    #
+    # Each call includes a generated `request_id` header. Caller-provided
+    # headers are merged afterward, so scenarios can override that value or add
+    # transport-specific headers such as content type and user agent.
+    #
+    # @param headers [Hash] HTTP headers merged after the generated request id
+    # @param read_timeout [Integer] read timeout in seconds
+    # @param open_timeout [Integer] connection open timeout in seconds
+    # @return [Hash] options compatible with `Nonnative::HTTPClient` calls
+    def http_options(headers: {}, read_timeout: 10, open_timeout: 10)
+      {
+        headers: { request_id: SecureRandom.uuid }.merge(headers),
+        read_timeout:,
+        open_timeout:
+      }
+    end
+
     # Builds and memoizes the gRPC channel arguments used by stubs created in this helper.
     #
     # @return [Hash] gRPC channel args


### PR DESCRIPTION
## What

- Added repository guidance that keeps local feature-harness endpoint assumptions and shared-bin CI preflight ownership from resurfacing as feature gaps.
- Exposed help output from the Ruby harness Makefile and ignored the temporary feature-gap ledger file.
- Centralized HTTP feature-harness request options behind `Bezeichner.http_options` and reused it from HTTP API, benchmark, and observability steps while preserving scenario request IDs.

## Why

- Shared HTTP request defaults keep generated request IDs, timeouts, and caller-specific headers consistent across the local feature harness.
- Repo-local guidance documents accepted review boundaries so future gap passes focus on actionable service changes.
- The Ruby harness command surface is discoverable from `test/` like other shared Make targets.

## Testing

- `PATH=/usr/local/opt/ruby@4/bin:$PATH gmake lint` - passed
- `PATH=/usr/local/opt/ruby@4/bin:$PATH gmake features` - passed, covering 61 scenarios and 122 steps
- `PATH=/usr/local/opt/ruby@4/bin:$PATH gmake -C test help` - passed
- `PATH=/usr/local/opt/ruby@4/bin:$PATH bundle exec ruby -Ilib -e "..."` - passed, covering `Bezeichner.http_options` header override and timeout return shape
- `git diff --check` - passed
