### PR TITLE
build(ci): tighten project workflow defaults

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,23 +14,23 @@ jobs:
       - restore_cache:
           name: restore go cache
           keys:
-            - bezeichner-go-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}-{{ checksum ".source-key" }}
+            - bezeichner-go-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}
             - bezeichner-go-cache-
       - restore_cache:
           name: restore ruby cache
           keys:
-            - bezeichner-ruby-cache-{{ checksum "test/Gemfile.lock" }}-{{ checksum "~/.ruby-version" }}-{{ checksum ".source-key" }}
+            - bezeichner-ruby-cache-{{ checksum "test/Gemfile.lock" }}-{{ checksum "~/.ruby-version" }}
             - bezeichner-ruby-cache-
       - run: make clean
       - run: make dep
       - save_cache:
           name: save go cache
-          key: bezeichner-go-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}-{{ checksum ".source-key" }}
+          key: bezeichner-go-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}
           paths:
             - ~/go/pkg/mod
       - save_cache:
           name: save ruby cache
-          key: bezeichner-ruby-cache-{{ checksum "test/Gemfile.lock" }}-{{ checksum "~/.ruby-version" }}-{{ checksum ".source-key" }}
+          key: bezeichner-ruby-cache-{{ checksum "test/Gemfile.lock" }}-{{ checksum "~/.ruby-version" }}
           paths:
             - test/vendor
       - restore_cache:
@@ -92,7 +92,7 @@ jobs:
       - restore_cache:
           name: restore go cache
           keys:
-            - bezeichner-go-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}-{{ checksum ".source-key" }}
+            - bezeichner-go-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}
             - bezeichner-go-cache-
       - restore_cache:
           name: restore go build cache

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist
 .source-key
 ISSUES.md
 FEATURES.md
+PROJECTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,18 @@ from `github.com/alexfalkowski/go-service/v2/id`.
 - Deployments and consumers are still expected to pin released version tags, and the versioned image tag is the deployment contract.
 - Only raise release ordering risk when the task explicitly concerns `latest` consumers, unpinned image deployment, versioned tag overwrite, partial versioned artifact publication, or changing the release/deploy contract.
 
+### GoReleaser config validation is owned by the release image
+
+- CircleCI's `version` job runs the external `package` command from
+  `alexfalkowski/release` / `alexfalkowski/docker/release`.
+- That release image's `release/package` script runs
+  `goreleaser check "$releaser"` before `goreleaser release`.
+- Reviewers should not flag the absence of a separate repository-local
+  GoReleaser config validation job as a project gap by default. Only raise it
+  with concrete evidence that the release image no longer validates
+  `.goreleaser.yml`, or that this repository has explicitly decided to own a
+  pre-release GoReleaser check locally.
+
 ## Request size limits (DoS protection)
 
 Limits are enforced in the domain layer:
@@ -226,6 +238,19 @@ These surface to clients as `InvalidArgument` via the gRPC error mapper (`intern
   concrete evidence of current workflow breakage.
 - Reviewers should not flag the lack of environment-configurable HTTP, gRPC, or
   observability endpoints as a feature gap by default.
+
+### Ruby runtime selection is owned by the shared CI image
+
+- The Ruby code under `test/` is feature-test harness code, not production
+  service code.
+- Ruby runtime selection for this harness is controlled by the external
+  `alexfalkowski/go` image from `alexfalkowski/docker/go`, which is the shared
+  service CI tooling image used by `.circleci/config.yml`.
+- Reviewers should not flag the absence of a repository-local `.ruby-version`,
+  `.tool-versions`, `mise.toml`, or Gemfile `ruby` directive as a project gap by
+  default. Only raise it with concrete evidence that the shared CI image no
+  longer supplies the expected runtime, or that this repository has explicitly
+  decided to own Ruby version selection locally for the test harness.
 
 If bundler fails loading native gems (e.g., `json` extension), one observed fix is rebuilding the gem:
 

--- a/api/Makefile
+++ b/api/Makefile
@@ -1,1 +1,2 @@
 include ../bin/build/make/buf.mak
+include ../bin/build/make/help.mak


### PR DESCRIPTION
## What

- Narrow CircleCI Go and Ruby dependency cache keys so they are invalidated by dependency and runtime-version changes instead of broad source changes.
- Keep Go build and lint caches source-sensitive, preserving invalidation for outputs that depend on repository source content.
- Add shared help discovery to the API Makefile while preserving the existing Buf lint dry-run default.
- Document review guardrails for GoReleaser validation ownership and Ruby runtime ownership in this service repository.
- Ignore PROJECTS.md project-gap audit output.

## Why

- Reduces dependency cache churn caused by unrelated source, documentation, config, or fixture edits.
- Makes API subdirectory commands discoverable through the same shared help target used by root and test command surfaces.
- Prevents future project workflow reviews from treating release-image GoReleaser validation or shared CI image Ruby runtime selection as local repository gaps without concrete evidence.

## Testing

- `circleci config validate .circleci/config.yml` - passed
- `make -C api help` - passed
- `make -C test help` - passed
- `make -C api -n` - passed
- `make -C api -n lint` - passed
- `make -C api -n generate` - passed
- `make -C api -n breaking` - passed
- `make -C api -n format` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
