### PR TITLE
build(ci): restore protobuf compatibility check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,8 +68,7 @@ jobs:
           key: bezeichner-go-lint-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-lint-version" }}-{{ checksum ".source-key" }}
           paths:
             - ~/.cache/golangci-lint
-      # TODO: re-enable after merging the intentional protobuf breaking change.
-      # - run: make proto-breaking
+      - run: make proto-breaking
       - run: make proto-stale
       - run: make sec
       - run: make features


### PR DESCRIPTION
## What

- Re-enable the `make proto-breaking` step in the CircleCI `build-service` job.
- Remove the temporary comment that disabled protobuf compatibility validation during the intentional breaking API change.

## Why

- The protobuf break has been handled, so CI should again catch accidental API incompatibilities before merge.

## Testing

- `git diff --check` - passed.
- `make proto-breaking` - passed.
