### PR TITLE
docs(agents): clarify typeid prefix contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,20 @@ from `github.com/alexfalkowski/go-service/v2/id`.
 - Registry: `internal/generator/generator.go:16-30`.
 - Applications are defined via `internal/generator/config.go:3-25`.
 
+### TypeID generator application-name contract
+
+- `typeid` is a Bezeichner-owned adapter around `go.jetify.com/typeid`, not a
+  `go-service/v2/id` generator.
+- The `typeid` generator intentionally uses the configured application name as
+  the native TypeID prefix.
+- Treat valid TypeID prefix syntax as part of the operator/application-name
+  contract for `kind: typeid`. Do **not** flag missing extra validation for
+  invalid TypeID prefixes, or request-time failures caused by invalid TypeID
+  application names, as a general code issue.
+- Only raise TypeID prefix validation concerns when the task explicitly concerns
+  changing the TypeID naming contract, making invalid configuration fail earlier,
+  or documenting TypeID application-name restrictions.
+
 ### Snowflake generator deployment assumption
 
 - Do **not** flag `internal/generator/snowflake.go` using Sonyflake default settings as a general bug.


### PR DESCRIPTION
## What

- Added repository agent guidance for the TypeID generator application-name contract.
- Clarified that Bezeichner owns the TypeID adapter around `go.jetify.com/typeid` and intentionally uses the configured application name as the native TypeID prefix.
- Scoped future review behavior so invalid TypeID prefixes are not raised as general code issues unless the task is explicitly about that contract, earlier validation, or documentation.

## Why

- Prevents future code-issue and reliability audits from re-raising an accepted TypeID application-name contract as a generic defect.
- Keeps generator review guidance aligned with the existing Snowflake deployment-assumption exception in the same repository instruction file.

## Testing

- `make lint` - passed
- Service tests were not run because this is an agent-guidance documentation change with no runtime behavior change.
