### PR TITLE
docs(readme): clarify typeid prefix contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ validation during startup.
 Generated identifiers are prefixed with the application name followed by `_`.
 For example, an application named `uuid` returns identifiers like `uuid_<uuid>`.
 The `typeid` generator uses the application name as the native TypeID prefix.
+For `kind: typeid`, choose application names that are valid TypeID prefixes:
+lowercase ASCII letters and underscores only (`[a-z_]`), at most 63 characters,
+and not starting or ending with `_`.
 
 Supported built-in kinds (at time of writing):
 

--- a/internal/generator/doc.go
+++ b/internal/generator/doc.go
@@ -47,7 +47,10 @@
 //   - "snowflake": application-prefixed Sonyflake-based numeric ID
 //     (decimal string)
 //   - "nanoid": application-prefixed NanoID string
-//   - "typeid": TypeID string using the application name as the TypeID prefix
+//   - "typeid": TypeID string using the application name as the TypeID prefix.
+//     Application names used with "typeid" must satisfy TypeID prefix syntax:
+//     lowercase ASCII letters and underscores only, at most 63 characters, and
+//     no leading or trailing underscore.
 //
 // # Errors
 //

--- a/internal/generator/typeid.go
+++ b/internal/generator/typeid.go
@@ -5,10 +5,17 @@ import (
 	"go.jetify.com/typeid"
 )
 
-// TypeID generator.
+// TypeID generates native TypeIDs using the application name as the TypeID
+// prefix.
+//
+// Application names used with this generator must satisfy TypeID prefix syntax:
+// lowercase ASCII letters and underscores only, at most 63 characters, and no
+// leading or trailing underscore.
 type TypeID struct{}
 
-// Generate a TypeID prefixed with the application name.
+// Generate returns a TypeID prefixed with the application name.
+//
+// It panics if app.Name violates the TypeID prefix contract.
 func (t *TypeID) Generate(_ context.Context, app *Application) string {
 	return typeid.Must(typeid.WithPrefix(app.Name)).String()
 }

--- a/test/lib/bezeichner/v1/http.rb
+++ b/test/lib/bezeichner/v1/http.rb
@@ -28,9 +28,10 @@ module Bezeichner
     #
     # ## Error responses
     #
-    # The HTTP gateway uses the gRPC handler error mapping and renders errors as HTTP
-    # status responses. `InvalidArgument` is returned as HTTP 400, `NotFound` as HTTP
-    # 404, and safe error messages are returned as `text/error` bodies.
+    # The HTTP gateway uses the same domain error categories as gRPC and renders
+    # them as HTTP status responses. `InvalidArgument` is returned as HTTP 400,
+    # `NotFound` as HTTP 404, and safe error messages are returned as
+    # `text/error` bodies.
     #
     # ## Options
     #


### PR DESCRIPTION
## What

- Documented the TypeID application-name prefix contract for operators in the generator configuration guidance.
- Added maintainer-facing GoDoc for the TypeID generator and package-level built-in kind list.
- Corrected the Ruby HTTP test helper RDoc so it describes shared domain error categories instead of a gRPC handler dependency.

## Why

- Prevents operators and maintainers from inferring that any non-empty Bezeichner application name is valid for `kind: typeid`.
- Keeps the accepted TypeID prefix contract visible in the user-facing configuration docs and nearby generator documentation.

## Testing

- `make lint` - passed
- `go list ./...` - passed
- `git diff --check` - passed
- `make proto-lint` - passed
- Generated protobuf and Ruby service stubs were checked directly with `git diff --exit-code -- ...` and had no diff.
- `make proto-stale` was not usable with this dirty working tree because it fails on the intentional documentation diff.
- Service tests were not run because the change is documentation-only.
