### PR TITLE
feat(limits): configure request size caps

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,12 @@ linters:
   settings:
     lll:
       line-length: 140
+    tagliatelle:
+      case:
+        rules:
+          json: snake
+          toml: snake
+          yaml: snake
   exclusions:
     generated: lax
     presets:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,7 @@ The v1 module wires transports and the domain service:
 
 - Domain logic: `internal/api/ids/`
   - `Identifier.Generate` and `Identifier.Map` (`internal/api/ids/ids.go`).
-  - Request-size limits are enforced here (`internal/api/ids/limits.go`).
+  - Request-size limits are enforced here using `internal/limits.Config`.
 - gRPC transport:
   - `internal/api/v1/transport/grpc/*` implements the protobuf service.
   - Errors are mapped to gRPC status codes in `internal/api/v1/transport/grpc/grpc.go:27-41`.
@@ -183,8 +183,8 @@ from `github.com/alexfalkowski/go-service/v2/id`.
 
 Limits are enforced in the domain layer:
 
-- `GenerateIdentifiers`: `count` is capped (`internal/api/ids/ids.go:33-36`, `internal/api/ids/limits.go:5-8`).
-- `MapIdentifiers`: number of IDs is capped (`internal/api/ids/ids.go:62-65`).
+- `GenerateIdentifiers`: `count` is capped in `internal/api/ids/ids.go` using `internal/limits.Config`.
+- `MapIdentifiers`: number of IDs is capped in `internal/api/ids/ids.go` using `internal/limits.Config`.
 
 These surface to clients as `InvalidArgument` via the gRPC error mapper (`internal/api/v1/transport/grpc/grpc.go:32-34`).
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ map reserved for transport/service metadata.
 > [!NOTE]
 > HTTP is not a separate REST API. It is an RPC gateway over the same protobuf service contract used by gRPC.
 > [!WARNING]
-> Both endpoints enforce request-size limits in the domain layer for basic DoS protection. `GenerateIdentifiers.count` and the `MapIdentifiers.ids` list length are capped at `1000`; larger requests fail with `InvalidArgument`.
+> Both endpoints enforce request-size limits in the domain layer for basic DoS protection. By default, `GenerateIdentifiers.count` and the `MapIdentifiers.ids` list length are capped at `1000`; larger requests fail with `InvalidArgument`.
 
 Unknown generator applications, unknown mapper applications, unresolved generator kinds, and omitted mapper configuration fail with `NotFound`.
 
@@ -115,6 +115,20 @@ mapper:
 > [!IMPORTANT]
 > Mapping classifies each input ID. Known IDs are returned in `mapped`; missing IDs are returned in `unmapped`. Consumers decide whether unmapped IDs should be ignored, reported, retried, or treated as failures.
 > The `mapper` block is optional at startup. If it is omitted, all `MapIdentifiers` requests fail with `NotFound`.
+
+### 🚧 Request limit configuration
+
+Request limits configure Bezeichner-owned per-request item caps:
+
+```yaml
+limits:
+  generate_count: 1000
+  map_ids: 1000
+```
+
+Both values are optional and default to `1000` when omitted. Set lower values
+for smaller deployments or stricter abuse controls. Requests above the effective
+limit fail with `InvalidArgument`.
 
 ### ❤️ Health configuration
 
@@ -250,7 +264,7 @@ statuses with safe `text/error` response bodies:
 
 | gRPC/domain error | HTTP status | Common triggers                                                                                                |
 | ----------------- | ----------- | -------------------------------------------------------------------------------------------------------------- |
-| `InvalidArgument` | `400`       | `GenerateIdentifiers.count > 1000` or more than `1000` IDs to map                                              |
+| `InvalidArgument` | `400`       | `GenerateIdentifiers.count` or `MapIdentifiers.ids` exceeds the configured request limit                       |
 | `NotFound`        | `404`       | unknown generator application, unknown mapper application, unresolved generator kind, or omitted mapper config |
 
 > [!NOTE]

--- a/api/bezeichner/v1/service.pb.go
+++ b/api/bezeichner/v1/service.pb.go
@@ -35,8 +35,8 @@ type GenerateIdentifiersRequest struct {
 	// A zero value is valid when application resolves and returns an empty ids
 	// list.
 	//
-	// The maximum accepted count is 1000. Larger requests fail with
-	// InvalidArgument.
+	// The effective maximum is configured by service operators and defaults to
+	// 1000. Larger requests fail with InvalidArgument.
 	Count         uint64 `protobuf:"varint,2,opt,name=count,proto3" json:"count,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -161,8 +161,8 @@ type MapIdentifiersRequest struct {
 	// the application is not configured, MapIdentifiers fails with NotFound
 	// before mapping.
 	//
-	// The maximum accepted list length is 1000. Larger requests fail with
-	// InvalidArgument.
+	// The effective maximum list length is configured by service operators and
+	// defaults to 1000. Larger requests fail with InvalidArgument.
 	Ids           []string `protobuf:"bytes,2,rep,name=ids,proto3" json:"ids,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/api/bezeichner/v1/service.proto
+++ b/api/bezeichner/v1/service.proto
@@ -19,8 +19,8 @@ message GenerateIdentifiersRequest {
   // A zero value is valid when application resolves and returns an empty ids
   // list.
   //
-  // The maximum accepted count is 1000. Larger requests fail with
-  // InvalidArgument.
+  // The effective maximum is configured by service operators and defaults to
+  // 1000. Larger requests fail with InvalidArgument.
   uint64 count = 2;
 }
 
@@ -53,8 +53,8 @@ message MapIdentifiersRequest {
   // the application is not configured, MapIdentifiers fails with NotFound
   // before mapping.
   //
-  // The maximum accepted list length is 1000. Larger requests fail with
-  // InvalidArgument.
+  // The effective maximum list length is configured by service operators and
+  // defaults to 1000. Larger requests fail with InvalidArgument.
   repeated string ids = 2;
 }
 
@@ -80,15 +80,15 @@ message MapIdentifiersResponse {
 service Service {
   // GenerateIdentifiers generates identifiers for a configured application.
   //
-  // It returns InvalidArgument when count exceeds 1000, and NotFound when the
-  // application or generator kind cannot be resolved.
+  // It returns InvalidArgument when count exceeds the configured limit, and
+  // NotFound when the application or generator kind cannot be resolved.
   rpc GenerateIdentifiers(GenerateIdentifiersRequest) returns (GenerateIdentifiersResponse) {}
 
   // MapIdentifiers classifies identifiers through the configured application
   // mapping.
   //
-  // It returns InvalidArgument when more than 1000 identifiers are requested,
-  // and NotFound when mapper configuration is omitted or the application is not
-  // configured.
+  // It returns InvalidArgument when more identifiers than the configured limit
+  // are requested, and NotFound when mapper configuration is omitted or the
+  // application is not configured.
   rpc MapIdentifiers(MapIdentifiersRequest) returns (MapIdentifiersResponse) {}
 }

--- a/api/bezeichner/v1/service_grpc.pb.go
+++ b/api/bezeichner/v1/service_grpc.pb.go
@@ -31,15 +31,15 @@ const (
 type ServiceClient interface {
 	// GenerateIdentifiers generates identifiers for a configured application.
 	//
-	// It returns InvalidArgument when count exceeds 1000, and NotFound when the
-	// application or generator kind cannot be resolved.
+	// It returns InvalidArgument when count exceeds the configured limit, and
+	// NotFound when the application or generator kind cannot be resolved.
 	GenerateIdentifiers(ctx context.Context, in *GenerateIdentifiersRequest, opts ...grpc.CallOption) (*GenerateIdentifiersResponse, error)
 	// MapIdentifiers classifies identifiers through the configured application
 	// mapping.
 	//
-	// It returns InvalidArgument when more than 1000 identifiers are requested,
-	// and NotFound when mapper configuration is omitted or the application is not
-	// configured.
+	// It returns InvalidArgument when more identifiers than the configured limit
+	// are requested, and NotFound when mapper configuration is omitted or the
+	// application is not configured.
 	MapIdentifiers(ctx context.Context, in *MapIdentifiersRequest, opts ...grpc.CallOption) (*MapIdentifiersResponse, error)
 }
 
@@ -79,15 +79,15 @@ func (c *serviceClient) MapIdentifiers(ctx context.Context, in *MapIdentifiersRe
 type ServiceServer interface {
 	// GenerateIdentifiers generates identifiers for a configured application.
 	//
-	// It returns InvalidArgument when count exceeds 1000, and NotFound when the
-	// application or generator kind cannot be resolved.
+	// It returns InvalidArgument when count exceeds the configured limit, and
+	// NotFound when the application or generator kind cannot be resolved.
 	GenerateIdentifiers(context.Context, *GenerateIdentifiersRequest) (*GenerateIdentifiersResponse, error)
 	// MapIdentifiers classifies identifiers through the configured application
 	// mapping.
 	//
-	// It returns InvalidArgument when more than 1000 identifiers are requested,
-	// and NotFound when mapper configuration is omitted or the application is not
-	// configured.
+	// It returns InvalidArgument when more identifiers than the configured limit
+	// are requested, and NotFound when mapper configuration is omitted or the
+	// application is not configured.
 	MapIdentifiers(context.Context, *MapIdentifiersRequest) (*MapIdentifiersResponse, error)
 	mustEmbedUnimplementedServiceServer()
 }

--- a/internal/api/ids/doc.go
+++ b/internal/api/ids/doc.go
@@ -10,7 +10,7 @@
 //   - Generate: produce one or more identifiers for a named application.
 //   - Map: classify a list of existing identifiers as mapped or unmapped.
 //
-// Both operations enforce fixed request-size limits as a simple DoS-protection
+// Both operations enforce request-size limits as a simple DoS-protection
 // mechanism. When limits are exceeded, Generate/Map return ErrInvalidArgument.
 //
 // # Configuration

--- a/internal/api/ids/errors.go
+++ b/internal/api/ids/errors.go
@@ -2,14 +2,9 @@ package ids
 
 import "github.com/alexfalkowski/go-service/v2/errors"
 
-const (
-	maxGenerateCount = 1000
-	maxMapIDs        = 1000
-)
-
 // ErrInvalidArgument indicates the caller supplied an invalid request.
 //
-// In this package it is returned when a request exceeds the fixed domain limits,
+// In this package it is returned when a request exceeds the domain limits,
 // for example an excessive generate count or too many IDs to map.
 //
 // Use IsInvalidArgument to classify errors without relying on error strings.

--- a/internal/api/ids/ids.go
+++ b/internal/api/ids/ids.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/alexfalkowski/bezeichner/internal/generator"
+	"github.com/alexfalkowski/bezeichner/internal/limits"
 	"github.com/alexfalkowski/bezeichner/internal/mapper"
 	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/errors"
@@ -27,9 +28,10 @@ var ErrNotFound = errors.New("not found")
 //   - generator configuration (to resolve an application by name),
 //   - and a generator registry (to resolve a generator by application kind).
 //
+// Limits configuration is optional and defaults to the built-in domain limits.
 // Mapper configuration is optional. When it is omitted, Map returns ErrNotFound.
-func NewIdentifier(gc *generator.Config, mc *mapper.Config, gs generator.Generators) *Identifier {
-	return &Identifier{generatorConfig: gc, mapperConfig: mc, generators: gs}
+func NewIdentifier(generator *generator.Config, mapper *mapper.Config, generators generator.Generators, limits *limits.Config) *Identifier {
+	return &Identifier{generatorConfig: generator, mapperConfig: mapper, generators: generators, limits: limits}
 }
 
 // Identifier is the domain service that generates and maps identifiers.
@@ -40,6 +42,7 @@ type Identifier struct {
 	generatorConfig *generator.Config
 	mapperConfig    *mapper.Config
 	generators      generator.Generators
+	limits          *limits.Config
 }
 
 // Generate returns count identifiers for the given application name.
@@ -51,11 +54,11 @@ type Identifier struct {
 // generator kind can be resolved.
 //
 // Errors:
-//   - ErrInvalidArgument if count exceeds the fixed domain limit.
+//   - ErrInvalidArgument if count exceeds the configured domain limit.
 //   - ErrNotFound if the application name does not exist, or if the application
 //     kind cannot be resolved to a generator.
 func (s *Identifier) Generate(ctx context.Context, application string, count uint64) ([]string, error) {
-	if count > maxGenerateCount {
+	if count > s.limits.MaxGenerateCount() {
 		return nil, ErrInvalidArgument
 	}
 
@@ -93,11 +96,11 @@ func (s *Identifier) Generate(ctx context.Context, application string, count uin
 // application configuration is present.
 //
 // Errors:
-//   - ErrInvalidArgument if len(ids) exceeds the fixed domain limit.
+//   - ErrInvalidArgument if len(ids) exceeds the configured domain limit.
 //   - ErrNotFound if mapper configuration is omitted, the application is
 //     missing.
 func (s *Identifier) Map(application string, ids []string) (mapper.Identifiers, []string, error) {
-	if len(ids) > maxMapIDs {
+	if uint64(len(ids)) > s.limits.MaxMapIDs() {
 		return nil, nil, ErrInvalidArgument
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"github.com/alexfalkowski/bezeichner/internal/generator"
 	"github.com/alexfalkowski/bezeichner/internal/health"
+	"github.com/alexfalkowski/bezeichner/internal/limits"
 	"github.com/alexfalkowski/bezeichner/internal/mapper"
 	"github.com/alexfalkowski/go-service/v2/config"
 )
@@ -11,6 +12,7 @@ import (
 type Config struct {
 	Health         *health.Config    `yaml:"health,omitempty" json:"health,omitempty" toml:"health,omitempty" validate:"required"`
 	Generator      *generator.Config `yaml:"generator,omitempty" json:"generator,omitempty" toml:"generator,omitempty" validate:"required"`
+	Limits         *limits.Config    `yaml:"limits,omitempty" json:"limits,omitempty" toml:"limits,omitempty"`
 	Mapper         *mapper.Config    `yaml:"mapper,omitempty" json:"mapper,omitempty" toml:"mapper,omitempty"`
 	*config.Config `yaml:",inline" json:",inline" toml:",inline" validate:"required"`
 }
@@ -25,6 +27,10 @@ func healthConfig(cfg *Config) *health.Config {
 
 func generatorConfig(cfg *Config) *generator.Config {
 	return cfg.Generator
+}
+
+func limitsConfig(cfg *Config) *limits.Config {
+	return cfg.Limits
 }
 
 func mapperConfig(cfg *Config) *mapper.Config {

--- a/internal/config/doc.go
+++ b/internal/config/doc.go
@@ -4,7 +4,7 @@
 // This package is intentionally small and focused:
 //
 //   - It declares Config, the root configuration struct that aggregates
-//     configuration for sub-systems (health, generator, mapper) and embeds the
+//     configuration for sub-systems (health, generator, limits, mapper) and embeds the
 //     shared service config type from go-service.
 //   - It exposes a DI module that loads configuration from the configured source
 //     (file/env/etc. as determined by the runtime) and makes typed sub-configs
@@ -15,13 +15,15 @@
 // Config is the service's root configuration. It includes pointers to:
 //   - internal/health.Config
 //   - internal/generator.Config
+//   - internal/limits.Config
 //   - internal/mapper.Config
 //
 // and embeds *go-service/v2/config.Config for common service settings.
 //
-// Health and generator configuration are required at startup. Mapper
-// configuration is optional; when omitted, mapping requests fail with the domain
-// ErrNotFound error.
+// Health and generator configuration are required at startup. Limits and mapper
+// configuration are optional; omitted limits use domain defaults, while omitted
+// mapper configuration makes mapping requests fail with the domain ErrNotFound
+// error.
 //
 // # Dependency injection
 //

--- a/internal/config/module.go
+++ b/internal/config/module.go
@@ -11,5 +11,6 @@ var Module = di.Module(
 	di.Decorate(decorateConfig),
 	di.Constructor(healthConfig),
 	di.Constructor(generatorConfig),
+	di.Constructor(limitsConfig),
 	di.Constructor(mapperConfig),
 )

--- a/internal/limits/config.go
+++ b/internal/limits/config.go
@@ -1,0 +1,30 @@
+package limits
+
+const (
+	defaultGenerateCount = 1000
+	defaultMapIDs        = 1000
+)
+
+// Config configures per-request item-count limits.
+type Config struct {
+	GenerateCount uint64 `yaml:"generate_count,omitempty" json:"generate_count,omitempty" toml:"generate_count,omitempty"`
+	MapIDs        uint64 `yaml:"map_ids,omitempty" json:"map_ids,omitempty" toml:"map_ids,omitempty"`
+}
+
+// MaxGenerateCount returns the effective GenerateIdentifiers count limit.
+func (c *Config) MaxGenerateCount() uint64 {
+	if c == nil || c.GenerateCount == 0 {
+		return defaultGenerateCount
+	}
+
+	return c.GenerateCount
+}
+
+// MaxMapIDs returns the effective MapIdentifiers ids limit.
+func (c *Config) MaxMapIDs() uint64 {
+	if c == nil || c.MapIDs == 0 {
+		return defaultMapIDs
+	}
+
+	return c.MapIDs
+}

--- a/internal/limits/doc.go
+++ b/internal/limits/doc.go
@@ -1,0 +1,2 @@
+// Package limits contains request limit configuration.
+package limits

--- a/test/.config/server.yml
+++ b/test/.config/server.yml
@@ -1,6 +1,9 @@
 environment: production
 id:
   kind: uuid
+limits:
+  generate_count: 2
+  map_ids: 2
 mapper:
   applications:
     - name: uuid

--- a/test/features/v1/transport/grpc/api.feature
+++ b/test/features/v1/transport/grpc/api.feature
@@ -30,15 +30,15 @@ Feature: gRPC API
   Scenario: Generate maximum identifiers for existing applications
     When I request to generate identifiers with gRPC:
       | application | uuid |
-      | count       | 1000 |
+      | count       | 2 |
     Then I should receive generated identifiers from gRPC:
       | application | uuid |
-      | count       | 1000 |
+      | count       | 2 |
 
   Scenario: Generate too many identifiers for existing applications
     When I request to generate identifiers with gRPC:
       | application | uuid |
-      | count       | 1001 |
+      | count       | 3 |
     Then I should receive an invalid argument error from gRPC
 
   Scenario Outline: Generate identifiers for missing applications
@@ -68,12 +68,12 @@ Feature: gRPC API
       | ulid        | req1      | req1:ulid_resp1      |          |
 
   Scenario: Map maximum identifiers
-    When I request to map 1000 identifiers with gRPC:
+    When I request to map 2 identifiers with gRPC:
       | application | uuid |
-    Then I should receive 1000 unmapped identifiers from gRPC
+    Then I should receive 2 unmapped identifiers from gRPC
 
   Scenario: Map too many identifiers
-    When I request to map 1001 identifiers with gRPC:
+    When I request to map 3 identifiers with gRPC:
       | application | uuid |
     Then I should receive an invalid argument error from gRPC
 

--- a/test/features/v1/transport/http/api.feature
+++ b/test/features/v1/transport/http/api.feature
@@ -30,15 +30,15 @@ Feature: HTTP API
   Scenario: Generate maximum identifiers for existing applications
     When I request to generate identifiers with HTTP:
       | application | uuid |
-      | count       | 1000 |
+      | count       | 2 |
     Then I should receive generated identifiers from HTTP:
       | application | uuid |
-      | count       | 1000 |
+      | count       | 2 |
 
   Scenario: Generate too many identifiers for existing applications
     When I request to generate identifiers with HTTP:
       | application | uuid |
-      | count       | 1001 |
+      | count       | 3 |
     Then I should receive an invalid argument error from HTTP
 
   Scenario Outline: Generate identifiers for missing applications
@@ -68,12 +68,12 @@ Feature: HTTP API
       | ulid        | req1      | req1:ulid_resp1      |          |
 
   Scenario: Map maximum identifiers
-    When I request to map 1000 identifiers with HTTP:
+    When I request to map 2 identifiers with HTTP:
       | application | uuid |
-    Then I should receive 1000 unmapped identifiers from HTTP
+    Then I should receive 2 unmapped identifiers from HTTP
 
   Scenario: Map too many identifiers
-    When I request to map 1001 identifiers with HTTP:
+    When I request to map 3 identifiers with HTTP:
       | application | uuid |
     Then I should receive an invalid argument error from HTTP
 

--- a/test/lib/bezeichner.rb
+++ b/test/lib/bezeichner.rb
@@ -2,7 +2,6 @@
 
 require 'securerandom'
 require 'yaml'
-require 'base64'
 require 'open3'
 require 'timeout'
 

--- a/test/lib/bezeichner/v1/service_services_pb.rb
+++ b/test/lib/bezeichner/v1/service_services_pb.rb
@@ -18,15 +18,15 @@ module Bezeichner
 
         # GenerateIdentifiers generates identifiers for a configured application.
         #
-        # It returns InvalidArgument when count exceeds 1000, and NotFound when the
-        # application or generator kind cannot be resolved.
+        # It returns InvalidArgument when count exceeds the configured limit, and
+        # NotFound when the application or generator kind cannot be resolved.
         rpc :GenerateIdentifiers, ::Bezeichner::V1::GenerateIdentifiersRequest, ::Bezeichner::V1::GenerateIdentifiersResponse
         # MapIdentifiers classifies identifiers through the configured application
         # mapping.
         #
-        # It returns InvalidArgument when more than 1000 identifiers are requested,
-        # and NotFound when mapper configuration is omitted or the application is not
-        # configured.
+        # It returns InvalidArgument when more identifiers than the configured limit
+        # are requested, and NotFound when mapper configuration is omitted or the
+        # application is not configured.
         rpc :MapIdentifiers, ::Bezeichner::V1::MapIdentifiersRequest, ::Bezeichner::V1::MapIdentifiersResponse
       end
 


### PR DESCRIPTION
## What

- Add configurable request size caps for GenerateIdentifiers and MapIdentifiers under the existing `limits` config key.
- Move cap ownership into `internal/limits.Config` while keeping request enforcement in the ids domain service.
- Update the single feature-test server config to use lower caps and adjust gRPC/HTTP scenarios to assert configured behavior through the existing Nonnative startup path.
- Update README, proto comments, generated Go/Ruby protobuf comments, AGENTS guidance, and lint tag-case rules for snake_case config tags.

## Why

- Operators can tune per-request caps without code changes while preserving the existing default of 1000 when the config is omitted.
- The feature coverage stays on the normal one-process feature harness instead of adding separate configs, ports, or dynamic startup machinery.

## Testing

- `make proto-lint` - passed
- `make lint` - passed
- `make specs` - passed
- `make features` - passed
- `zsh -lic 'make proto-generate'` - passed with Buf remote plugin access; the changed-file set stayed stable after generation
- `git diff --check` - passed
- `make proto-stale` was not run locally because it runs `git diff --exit-code` and fails on any intended uncommitted working-tree diff; proto generation was run directly instead and CI will run stale checks after commit.
