### PR TITLE
build(ci): restore protobuf compatibility gate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
           key: bezeichner-go-lint-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-lint-version" }}-{{ checksum ".source-key" }}
           paths:
             - ~/.cache/golangci-lint
-      # - run: make proto-breaking
+      - run: make proto-breaking
       - run: make proto-stale
       - run: make sec
       - run: make features


### PR DESCRIPTION
## What

- Re-enable the CircleCI `make proto-breaking` step in the `build-service` job.
- Keep the check immediately before `make proto-stale`, restoring the protobuf contract validation order.

## Why

- FEATURE-2's breaking API change is now merged, so the protobuf breaking check passes against the current master baseline.
- Re-enabling the gate restores CI coverage for future accidental protobuf contract breaks.

## Testing

- `make proto-breaking` - passed
- `make lint` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
