### PR TITLE
docs(service-guidance): align examples and package comments with runtime behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
 
 - Language: **Go**; see `go.mod` for module path and toolchain details.
 - API contract: `api/bezeichner/v1/service.proto` (+ generated Go stubs under `api/` and Ruby stubs under `test/lib`).
-- Build tooling: the root `Makefile` is a thin wrapper around the **`bin/` git submodule** (see `.gitmodules:1-3` and `Makefile:1-3`).
+- Build tooling: the root `Makefile` is a thin wrapper around the **`bin/` git submodule** (see `.gitmodules:1-3` and `Makefile:1-5`).
 
 ## First steps
 
@@ -31,9 +31,10 @@ make dep
 
 Observed behavior:
 - Go deps are vendored by the shared dependency target and the test-binary
-  build uses vendored dependencies (see `bin/build/make/_service.mak:184-186`).
+  build uses vendored dependencies (see `bin/build/make/_service.mak:135-155`
+  and `bin/build/make/_service.mak:195-197`).
 - Ruby deps for feature tests live under `test/` and are installed by the
-  shared Ruby dependency target (see `bin/build/make/ruby.mak:15-21` and
+  shared Ruby dependency target (see `bin/build/make/ruby.mak:17-22` and
   `test/.bundle/config:1-2`).
 
 ## Essential commands
@@ -45,7 +46,7 @@ make build        # builds ./bezeichner (release binary)
 make build-test   # builds ./bezeichner test binary (-tags features, -race, coverage enabled)
 ```
 
-Implementation: `bin/build/make/_service.mak:180-186`.
+Implementation: `bin/build/make/_service.mak:191-197`.
 
 ### Test
 
@@ -57,8 +58,8 @@ make coverage     # HTML + func coverage reports
 ```
 
 Notes:
-- `main_test.go` is guarded by build tag `features` (`main_test.go:1-10`).
-- `make features` depends on `make build-test` (see `bin/build/make/_service.mak:100-102`).
+- `main_test.go` is guarded by build tag `features` (`main_test.go:1-11`).
+- `make features` depends on `make build-test` (see `bin/build/make/_service.mak:107-109`).
 
 ### Lint / format / security
 
@@ -70,7 +71,7 @@ make sec
 ```
 
 - Go linting and formatting are owned by `make lint`, `make fix-lint`, and
-  `make format`. Generated protobuf code is excluded (`.golangci.yml:33-43`).
+  `make format`. Generated protobuf code is excluded (`.golangci.yml:33-51`).
 
 ### Protobuf (Buf)
 
@@ -103,13 +104,13 @@ make start
 make stop
 ```
 
-These call scripts under `bin/build/docker/env` (see `bin/build/make/_service.mak:230-236`).
+These call scripts under `bin/build/docker/env` (see `bin/build/make/_service.mak:239-245`).
 
 ## Code organization
 
 ### Entry points / CLI
 
-- `main.go` constructs a `go-service/v2/cli` application and registers the `server` command (`main.go:9-15`).
+- `main.go` constructs a `go-service/v2/cli` application and registers the `server` command (`main.go:10-15`).
 - The server command is registered in `internal/cmd/server.go:9-12` and wires DI via `internal/cmd/module.go:13-19`.
 
 ### Dependency injection (DI)
@@ -121,16 +122,17 @@ The service uses `go-service/v2/di` modules:
   - `config.Module`, `health.Module`, `generator.Module`, `v1.Module`
 
 The v1 module wires transports and the domain service:
-- `internal/api/v1/module.go:11-16`.
+- `internal/api/v1/module.go:11-17`.
 
 ### API layers
 
 - Domain logic: `internal/api/ids/`
-  - `Identifier.Generate` and `Identifier.Map` (`internal/api/ids/ids.go`).
+  - `Identifier.Applications`, `Identifier.Generate`, and `Identifier.Map`
+    (`internal/api/ids/applications.go` and `internal/api/ids/ids.go`).
   - Request-size limits are enforced here using `internal/limits.Config`.
 - gRPC transport:
   - `internal/api/v1/transport/grpc/*` implements the protobuf service.
-  - Errors are mapped to gRPC status codes in `internal/api/v1/transport/grpc/grpc.go:27-41`.
+  - Errors are mapped to gRPC status codes in `internal/api/v1/transport/grpc/error.go:9-15`.
 - HTTP transport:
   - `internal/api/v1/transport/http/http.go:9-13` routes HTTP RPC calls by gRPC full method name.
 
@@ -156,8 +158,8 @@ Generator implementations are in `internal/generator/*` and are selected by `App
 Standard kinds such as `uuid`, `ksuid`, `ulid`, `xid`, and `nanoid` are adapted
 from `github.com/alexfalkowski/go-service/v2/id`.
 
-- Registry: `internal/generator/generator.go:16-30`.
-- Applications are defined via `internal/generator/config.go:3-25`.
+- Registry: `internal/generator/generator.go:17-27`.
+- Applications are defined via `internal/generator/config.go:3-33`.
 
 ### TypeID generator application-name contract
 
@@ -186,13 +188,13 @@ Limits are enforced in the domain layer:
 - `GenerateIdentifiers`: `count` is capped in `internal/api/ids/ids.go` using `internal/limits.Config`.
 - `MapIdentifiers`: number of IDs is capped in `internal/api/ids/ids.go` using `internal/limits.Config`.
 
-These surface to clients as `InvalidArgument` via the gRPC error mapper (`internal/api/v1/transport/grpc/grpc.go:32-34`).
+These surface to clients as `InvalidArgument` via the gRPC error mapper (`internal/api/v1/transport/grpc/error.go:9-14`).
 
 ## Testing
 
 ### Go specs
 
-`make specs` runs gotestsum with race and coverage (see `bin/build/make/_service.mak:108-111`). Outputs land under `test/reports/`.
+`make specs` runs gotestsum with race and coverage (see `bin/build/make/_service.mak:115-118`). Outputs land under `test/reports/`.
 
 ### Feature tests (Ruby / nonnative)
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ mapper:
         req2: resp2
 ```
 
+Each configured mapper application must be non-null, have a non-empty `name`,
+and use a name that is unique within the list. Invalid application lists fail
+configuration validation during startup.
+
 > [!IMPORTANT]
 > Mapping returns one result for each input ID in the same order. Known IDs include `mapped`; missing IDs omit `mapped`. Consumers decide whether unmapped IDs should be ignored, reported, retried, or treated as failures.
 > The `mapper` block is optional at startup. If it is omitted, all `MapIdentifiers` requests fail with `NotFound`.
@@ -134,9 +138,13 @@ limits:
   map_ids: 1000
 ```
 
-Both values are optional and default to `1000` when omitted. Set lower values
-for smaller deployments or stricter abuse controls. Requests above the effective
-limit fail with `InvalidArgument`.
+Both values are optional. Omitted or zero values use the default of `1000`;
+zero does not disable the operation. Set a positive lower value for smaller
+deployments or stricter abuse controls. Requests above the effective limit fail
+with `InvalidArgument`.
+
+The representative `test/.config/server.yml` overrides both limits to `2`, so
+the local transport examples below stay within that fixture's limits.
 
 ### ❤️ Health configuration
 
@@ -217,11 +225,11 @@ grpcurl -plaintext \
   bezeichner.v1.Service/ListApplications
 ```
 
-Generate 3 IDs for application `uuid`:
+Generate 2 IDs for application `uuid`:
 
 ```sh
 grpcurl -plaintext \
-  -d '{"application":"uuid","count":"3"}' \
+  -d '{"application":"uuid","count":"2"}' \
   localhost:12000 \
   bezeichner.v1.Service/GenerateIdentifiers
 ```
@@ -277,7 +285,7 @@ Generate identifiers:
 curl -sS \
   -X POST \
   -H 'content-type: application/json' \
-  --data '{"application":"uuid","count":3}' \
+  --data '{"application":"uuid","count":2}' \
   http://localhost:11000/bezeichner.v1.Service/GenerateIdentifiers
 ```
 
@@ -327,7 +335,7 @@ that require release artifacts plus DockerHub or GitHub credentials. Use the
 local `test-docker` targets for image validation before pushing changes.
 
 > [!CAUTION]
-> The `snowflake` generator uses Sonyflake defaults. The intended deployment assumes normal Kubernetes pod networking where each concurrently running pod has a suitable private IPv4-derived machine ID. Re-evaluate that assumption for local multi-process deployments, `hostNetwork`, overlapping pod CIDRs, multi-cluster shared ID spaces, IPv6-only environments, or environments without private IPv4 addresses.
+> The `snowflake` generator uses Sonyflake defaults. The intended deployment assumes normal Kubernetes pod networking where each concurrently running pod has a suitable private IPv4-derived machine ID. Re-evaluate that assumption for local multi-process deployments, `hostNetwork`, overlapping pod CIDRs, multi-cluster shared ID spaces, IPv6-only environments, or environments without private IPv4 addresses. If Sonyflake cannot derive a machine ID, a generation request panics; use another generator kind when the deployment cannot meet this assumption.
 > [!IMPORTANT]
 > Deployments should pin released version tags instead of depending on the moving
 > `latest` Docker manifest. The release pipeline may update `latest` after
@@ -344,7 +352,7 @@ Bezeichner builds on established ID generation libraries:
 
 Service scaffolding and transport/DI patterns:
 
-- <https://github.com/alexfalkowski/go-service/v2>
+- <https://github.com/alexfalkowski/go-service>
 
 ## 🛠️ Development
 

--- a/internal/api/ids/applications.go
+++ b/internal/api/ids/applications.go
@@ -28,6 +28,11 @@ type Limits struct {
 }
 
 // Applications returns configured application names and safe capability data.
+//
+// Generator and mapper applications retain configuration order, generator
+// kinds are sorted, and Limits contains the effective values after defaults are
+// applied. Mapper application results contain names only; configured identifier
+// entries are not exposed.
 func (s *Identifier) Applications() *Applications {
 	return &Applications{
 		GeneratorApplications: s.generatorApplications(),

--- a/internal/api/ids/doc.go
+++ b/internal/api/ids/doc.go
@@ -5,13 +5,16 @@
 //
 // # Overview
 //
-// The main entry point is Identifier, which offers two operations:
+// The main entry point is Identifier, which offers three operations:
 //
+//   - Applications: report configured application names, supported generator
+//     kinds, and effective request limits without exposing mapper identifier
+//     entries.
 //   - Generate: produce one or more identifiers for a named application.
 //   - Map: map a list of existing identifiers while preserving input order.
 //
-// Both operations enforce request-size limits as a simple DoS-protection
-// mechanism. When limits are exceeded, Generate/Map return ErrInvalidArgument.
+// Generate and Map enforce request-size limits as a simple DoS-protection
+// mechanism. When limits are exceeded, they return ErrInvalidArgument.
 //
 // # Configuration
 //

--- a/internal/limits/config.go
+++ b/internal/limits/config.go
@@ -6,12 +6,16 @@ const (
 )
 
 // Config configures per-request item-count limits.
+//
+// A nil Config or a zero field uses the built-in default of 1000 items.
 type Config struct {
 	GenerateCount uint64 `yaml:"generate_count,omitempty" json:"generate_count,omitempty" toml:"generate_count,omitempty"`
 	MapIDs        uint64 `yaml:"map_ids,omitempty" json:"map_ids,omitempty" toml:"map_ids,omitempty"`
 }
 
 // MaxGenerateCount returns the effective GenerateIdentifiers count limit.
+//
+// It returns 1000 when c is nil or GenerateCount is zero.
 func (c *Config) MaxGenerateCount() uint64 {
 	if c == nil || c.GenerateCount == 0 {
 		return defaultGenerateCount
@@ -21,6 +25,8 @@ func (c *Config) MaxGenerateCount() uint64 {
 }
 
 // MaxMapIDs returns the effective MapIdentifiers ids limit.
+//
+// It returns 1000 when c is nil or MapIDs is zero.
 func (c *Config) MaxMapIDs() uint64 {
 	if c == nil || c.MapIDs == 0 {
 		return defaultMapIDs

--- a/internal/limits/doc.go
+++ b/internal/limits/doc.go
@@ -1,2 +1,6 @@
 // Package limits contains request limit configuration.
+//
+// A nil Config or a zero field uses the built-in default of 1000 items. Set a
+// positive field value to override the default; lower values configure stricter
+// limits. Zero does not disable an operation.
 package limits

--- a/internal/mapper/config.go
+++ b/internal/mapper/config.go
@@ -9,7 +9,10 @@ type Application struct {
 	Name        string      `yaml:"name" json:"name" toml:"name" validate:"required"`
 }
 
-// Config for mapper.
+// Config contains the mapper applications available to the service.
+//
+// Application entries must be non-nil, names must be non-empty, and names must
+// be unique.
 type Config struct {
 	Applications []*Application `yaml:"applications" json:"applications" toml:"applications" validate:"unique=Name,dive,required"`
 }

--- a/internal/mapper/doc.go
+++ b/internal/mapper/doc.go
@@ -12,6 +12,8 @@
 //	  input -> output
 //
 // For example, a configuration might map legacy IDs to new canonical IDs.
+// Application entries must be non-nil, names must be non-empty, and names must
+// be unique; invalid lists fail service configuration validation during startup.
 //
 // # Semantics
 //

--- a/test/lib/bezeichner.rb
+++ b/test/lib/bezeichner.rb
@@ -35,7 +35,7 @@ module Bezeichner
   class << self
     # Loads and memoizes the service configuration used by the feature test harness.
     #
-    # @return [Hash] configuration loaded by nonnative
+    # @return [Config::Options] configuration loaded by nonnative
     #
     # @example Load generator applications
     #   Bezeichner.config.dig('generator', 'applications')
@@ -56,6 +56,8 @@ module Bezeichner
     end
 
     # Builds per-call options for gRPC feature and benchmark requests.
+    #
+    # The deadline is set to 10 seconds after this method is called.
     #
     # @param metadata [Hash] gRPC metadata to send with the request
     # @return [Hash] gRPC call options
@@ -109,18 +111,21 @@ module Bezeichner
       # @return [Bezeichner::V1::HTTP]
       #
       # @example Generate identifiers over HTTP
-      #   Bezeichner::V1.http.generate('uuid', 3)
+      #   Bezeichner::V1.http.generate('uuid', 2)
       def http
         @http ||= Bezeichner::V1::HTTP.new('http://localhost:11000')
       end
 
       # Returns a gRPC stub for the Bezeichner v1 API.
       #
+      # Pass {Bezeichner.grpc_options} with each call to use the harness's
+      # 10-second deadline.
+      #
       # @return [Bezeichner::V1::Service::Stub]
       #
       # @example Generate identifiers over gRPC
-      #   req = Bezeichner::V1::GenerateIdentifiersRequest.new(application: 'uuid', count: 3)
-      #   Bezeichner::V1.grpc.generate_identifiers(req)
+      #   req = Bezeichner::V1::GenerateIdentifiersRequest.new(application: 'uuid', count: 2)
+      #   Bezeichner::V1.grpc.generate_identifiers(req, Bezeichner.grpc_options)
       def grpc
         @grpc ||= Bezeichner::V1::Service::Stub.new('localhost:12000', :this_channel_is_insecure, channel_args: Bezeichner.user_agent)
       end

--- a/test/lib/bezeichner/v1/http.rb
+++ b/test/lib/bezeichner/v1/http.rb
@@ -47,8 +47,8 @@ module Bezeichner
       # @param opts [Hash] options forwarded to {Nonnative::HTTPClient#post}
       # @return [Object] HTTP response as returned by {Nonnative::HTTPClient#post}
       #
-      # @example Generate three UUID identifiers for application "uuid"
-      #   Bezeichner::V1.http.generate('uuid', 3)
+      # @example Generate two UUID identifiers for application "uuid"
+      #   Bezeichner::V1.http.generate('uuid', 2)
       def generate(application, count, opts = {})
         post('/bezeichner.v1.Service/GenerateIdentifiers', { application:, count: }.to_json, opts)
       end


### PR DESCRIPTION
## What

- Correct the README and Ruby harness examples so they stay within the documented sample limits, and clarify mapper validation, request-limit defaults, and the Snowflake deployment failure mode.
- Expand GoDoc and RDoc for application discovery, effective limits, mapper configuration, harness configuration types, and bounded gRPC calls.
- Refresh repository guidance source references and replace the stale go-service dependency link without changing runtime behavior or generated contracts.

## Why

- Keep first-use commands executable against the endorsed sample configuration and make non-obvious operator and maintainer contracts discoverable before they cause failed requests, unsafe limit assumptions, or stale maintenance decisions.

## Testing

- `make lint` - passed; Go, Ruby, and protobuf linting completed with no issues.
- `make features` - passed; 69 scenarios and 138 steps covered the documented sample configuration and both transports.
- `go doc -all ./internal/api/ids`, `go doc -all ./internal/limits`, and `go doc -all ./internal/mapper` - passed; rendered package contracts match the implementation.
- Ruby harness contract assertion - passed; confirmed `Config::Options` and the 10-second gRPC deadline shape.
- `git diff --check` - passed.

AI-assisted-by: [Codex](https://openai.com/codex/)
